### PR TITLE
:sparkles: Add IChamber inheritance to Chamber

### DIFF
--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -128,7 +128,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _constituent The address of the constituent to add
      */
-    function addConstituent(address _constituent) external override onlyWizard {
+    function addConstituent(address _constituent) external onlyWizard {
         require(!isConstituent(_constituent), "Must not be constituent");
 
         constituents.push(_constituent);
@@ -141,7 +141,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _constituent The address of the constituent to remove
      */
-    function removeConstituent(address _constituent) external override onlyWizard {
+    function removeConstituent(address _constituent) external onlyWizard {
         require(isConstituent(_constituent), "Must be constituent");
 
         constituents.removeStorage(_constituent);
@@ -156,7 +156,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return bool True/False if the address is a manager or not
      */
-    function isManager(address _manager) public view override returns (bool) {
+    function isManager(address _manager) public view returns (bool) {
         return managers.contains(_manager);
     }
 
@@ -167,7 +167,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return bool True/False if the address is a wizard or not
      */
-    function isWizard(address _wizard) public view override returns (bool) {
+    function isWizard(address _wizard) public view returns (bool) {
         return wizards.contains(_wizard);
     }
 
@@ -178,7 +178,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return bool True/False if the address is a constituent or not
      */
-    function isConstituent(address _constituent) public view override returns (bool) {
+    function isConstituent(address _constituent) public view returns (bool) {
         return constituents.contains(_constituent);
     }
 
@@ -187,7 +187,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _manager The address of the manager to add
      */
-    function addManager(address _manager) external override onlyOwner {
+    function addManager(address _manager) external onlyOwner {
         require(!isManager(_manager), "Already manager");
         require(_manager != address(0), "Cannot add null address");
 
@@ -201,7 +201,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _manager The address of the manager to remove
      */
-    function removeManager(address _manager) external override onlyOwner {
+    function removeManager(address _manager) external onlyOwner {
         require(isManager(_manager), "Not a manager");
 
         managers.removeStorage(_manager);
@@ -214,7 +214,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _wizard The address of the wizard to add
      */
-    function addWizard(address _wizard) external override onlyManager {
+    function addWizard(address _wizard) external onlyManager {
         require(god.isWizard(_wizard), "Wizard not validated in ChamberGod");
         require(!isWizard(_wizard), "Wizard already in Chamber");
 
@@ -228,7 +228,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _wizard The address of the wizard to remove
      */
-    function removeWizard(address _wizard) external override onlyManager {
+    function removeWizard(address _wizard) external onlyManager {
         require(isWizard(_wizard), "Wizard not in chamber");
 
         wizards.removeStorage(_wizard);
@@ -242,7 +242,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return an array of addresses for the constituents
      */
-    function getConstituentsAddresses() external view override returns (address[] memory) {
+    function getConstituentsAddresses() external view returns (address[] memory) {
         return constituents;
     }
 
@@ -252,7 +252,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return an array of uint256 for the quantities of the constituents
      */
-    function getQuantities() external view override returns (uint256[] memory) {
+    function getQuantities() external view returns (uint256[] memory) {
         uint256[] memory quantities = new uint256[](constituents.length);
         for (uint256 i = 0; i < constituents.length; i++) {
             quantities[i] = constituentQuantities[constituents[i]];
@@ -268,12 +268,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return uint256 The quantity of the constituent
      */
-    function getConstituentQuantity(address _constituent)
-        external
-        view
-        override
-        returns (uint256)
-    {
+    function getConstituentQuantity(address _constituent) external view returns (uint256) {
         return constituentQuantities[_constituent];
     }
 
@@ -282,7 +277,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return address[] Array containing the addresses of the wizards of the Chamber
      */
-    function getWizards() external view override returns (address[] memory) {
+    function getWizards() external view returns (address[] memory) {
         return wizards;
     }
 
@@ -291,7 +286,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return address[] Array containing the addresses of the managers of the Chamber
      */
-    function getManagers() external view override returns (address[] memory) {
+    function getManagers() external view returns (address[] memory) {
         return managers;
     }
 
@@ -300,7 +295,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return address[] Array containing the addresses of the allowedContracts of the Chamber
      */
-    function getAllowedContracts() external view override returns (address[] memory) {
+    function getAllowedContracts() external view returns (address[] memory) {
         return allowedContracts;
     }
 
@@ -309,7 +304,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _target The address of the allowedContract to add
      */
-    function addAllowedContract(address _target) external override onlyManager {
+    function addAllowedContract(address _target) external onlyManager {
         require(god.isAllowedContract(_target), "Contract not allowed in ChamberGod");
         require(!isAllowedContract(_target), "Contract already allowed");
 
@@ -323,7 +318,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _target The address of the allowedContract to remove
      */
-    function removeAllowedContract(address _target) external override onlyManager {
+    function removeAllowedContract(address _target) external onlyManager {
         require(isAllowedContract(_target), "Contract not allowed");
 
         allowedContracts.removeStorage(_target);
@@ -338,7 +333,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @return bool True/False if the address is an allowedContract or not
      */
-    function isAllowedContract(address _target) public view override returns (bool) {
+    function isAllowedContract(address _target) public view returns (bool) {
         return allowedContracts.contains(_target);
     }
 
@@ -353,12 +348,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      * @param _recipient   The address of the recipient
      * @param _quantity    The quantity of the chamber to mint
      */
-    function mint(address _recipient, uint256 _quantity)
-        external
-        override
-        onlyWizard
-        nonReentrant
-    {
+    function mint(address _recipient, uint256 _quantity) external onlyWizard nonReentrant {
         _mint(_recipient, _quantity);
     }
 
@@ -369,7 +359,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      * @param _from          The address of the source to burn from
      * @param _quantity      The quantity of the chamber tokens to burn
      */
-    function burn(address _from, uint256 _quantity) external override onlyWizard nonReentrant {
+    function burn(address _from, uint256 _quantity) external onlyWizard nonReentrant {
         _burn(_from, _quantity);
     }
 
@@ -383,7 +373,6 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      */
     function withdrawTo(address _constituent, address _recipient, uint256 _quantity)
         external
-        override
         onlyWizard
     {
         if (_quantity > 0) {
@@ -410,7 +399,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      * list. Used by wizards. E.g. after an uncollateralized mint in the streaming fee wizard .
      *
      */
-    function updateQuantities() external override onlyWizard nonReentrant {
+    function updateQuantities() external onlyWizard nonReentrant {
         uint256 totalSupply = IERC20(address(this)).totalSupply();
         uint256 decimals = ERC20(address(this)).decimals();
         for (uint256 i = 0; i < constituents.length; i++) {
@@ -445,7 +434,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
         uint256 _minBuyQuantity,
         bytes memory _data,
         address payable _target
-    ) external override onlyWizard returns (uint256 tokenAmountBought) {
+    ) external onlyWizard returns (uint256 tokenAmountBought) {
         require(_target != address(this), "Cannot invoke the Chamber");
         require(isAllowedContract(_target), "Target not allowed");
         uint256 tokenAmountBefore = IERC20(_buyToken).balanceOf(address(this));

--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -35,10 +35,11 @@ import {Owned} from "solmate/auth/Owned.sol";
 import {ReentrancyGuard} from "solmate/utils/ReentrancyGuard.sol";
 import {ArrayUtils} from "./lib/ArrayUtils.sol";
 import {IChamberGod} from "./interfaces/IChamberGod.sol";
+import {IChamber} from "./interfaces/IChamber.sol";
 import {PreciseUnitMath} from "./lib/PreciseUnitMath.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
-contract Chamber is Owned, ReentrancyGuard, ERC20 {
+contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
     /*//////////////////////////////////////////////////////////////
                                  CONSTANTS
     //////////////////////////////////////////////////////////////*/
@@ -53,26 +54,6 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
     using SafeERC20 for IERC20;
     using Address for address;
     using PreciseUnitMath for uint256;
-
-    /*//////////////////////////////////////////////////////////////
-                                 EVENTS
-    //////////////////////////////////////////////////////////////*/
-
-    event ManagerAdded(address indexed _manager);
-
-    event ManagerRemoved(address indexed _manager);
-
-    event ConstituentAdded(address indexed _constituent);
-
-    event ConstituentRemoved(address indexed _constituent);
-
-    event WizardAdded(address indexed _wizard);
-
-    event WizardRemoved(address indexed _wizard);
-
-    event AllowedContractAdded(address indexed _allowedContract);
-
-    event AllowedContractRemoved(address indexed _allowedContract);
 
     /*//////////////////////////////////////////////////////////////
                             CHAMBER STORAGE
@@ -147,7 +128,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @param _constituent The address of the constituent to add
      */
-    function addConstituent(address _constituent) external onlyWizard {
+    function addConstituent(address _constituent) external override onlyWizard {
         require(!isConstituent(_constituent), "Must not be constituent");
 
         constituents.push(_constituent);
@@ -160,7 +141,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @param _constituent The address of the constituent to remove
      */
-    function removeConstituent(address _constituent) external onlyWizard {
+    function removeConstituent(address _constituent) external override onlyWizard {
         require(isConstituent(_constituent), "Must be constituent");
 
         constituents.removeStorage(_constituent);
@@ -175,7 +156,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return bool True/False if the address is a manager or not
      */
-    function isManager(address _manager) public view returns (bool) {
+    function isManager(address _manager) public view override returns (bool) {
         return managers.contains(_manager);
     }
 
@@ -186,7 +167,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return bool True/False if the address is a wizard or not
      */
-    function isWizard(address _wizard) public view returns (bool) {
+    function isWizard(address _wizard) public view override returns (bool) {
         return wizards.contains(_wizard);
     }
 
@@ -197,7 +178,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return bool True/False if the address is a constituent or not
      */
-    function isConstituent(address _constituent) public view returns (bool) {
+    function isConstituent(address _constituent) public view override returns (bool) {
         return constituents.contains(_constituent);
     }
 
@@ -206,7 +187,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @param _manager The address of the manager to add
      */
-    function addManager(address _manager) external onlyOwner {
+    function addManager(address _manager) external override onlyOwner {
         require(!isManager(_manager), "Already manager");
         require(_manager != address(0), "Cannot add null address");
 
@@ -220,7 +201,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @param _manager The address of the manager to remove
      */
-    function removeManager(address _manager) external onlyOwner {
+    function removeManager(address _manager) external override onlyOwner {
         require(isManager(_manager), "Not a manager");
 
         managers.removeStorage(_manager);
@@ -233,7 +214,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @param _wizard The address of the wizard to add
      */
-    function addWizard(address _wizard) external onlyManager {
+    function addWizard(address _wizard) external override onlyManager {
         require(god.isWizard(_wizard), "Wizard not validated in ChamberGod");
         require(!isWizard(_wizard), "Wizard already in Chamber");
 
@@ -247,7 +228,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @param _wizard The address of the wizard to remove
      */
-    function removeWizard(address _wizard) external onlyManager {
+    function removeWizard(address _wizard) external override onlyManager {
         require(isWizard(_wizard), "Wizard not in chamber");
 
         wizards.removeStorage(_wizard);
@@ -261,7 +242,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return an array of addresses for the constituents
      */
-    function getConstituentsAddresses() external view returns (address[] memory) {
+    function getConstituentsAddresses() external view override returns (address[] memory) {
         return constituents;
     }
 
@@ -271,7 +252,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return an array of uint256 for the quantities of the constituents
      */
-    function getQuantities() external view returns (uint256[] memory) {
+    function getQuantities() external view override returns (uint256[] memory) {
         uint256[] memory quantities = new uint256[](constituents.length);
         for (uint256 i = 0; i < constituents.length; i++) {
             quantities[i] = constituentQuantities[constituents[i]];
@@ -287,7 +268,12 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return uint256 The quantity of the constituent
      */
-    function getConstituentQuantity(address _constituent) external view returns (uint256) {
+    function getConstituentQuantity(address _constituent)
+        external
+        view
+        override
+        returns (uint256)
+    {
         return constituentQuantities[_constituent];
     }
 
@@ -296,7 +282,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return address[] Array containing the addresses of the wizards of the Chamber
      */
-    function getWizards() external view returns (address[] memory) {
+    function getWizards() external view override returns (address[] memory) {
         return wizards;
     }
 
@@ -305,7 +291,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return address[] Array containing the addresses of the managers of the Chamber
      */
-    function getManagers() external view returns (address[] memory) {
+    function getManagers() external view override returns (address[] memory) {
         return managers;
     }
 
@@ -314,7 +300,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return address[] Array containing the addresses of the allowedContracts of the Chamber
      */
-    function getAllowedContracts() external view returns (address[] memory) {
+    function getAllowedContracts() external view override returns (address[] memory) {
         return allowedContracts;
     }
 
@@ -323,7 +309,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @param _target The address of the allowedContract to add
      */
-    function addAllowedContract(address _target) external onlyManager {
+    function addAllowedContract(address _target) external override onlyManager {
         require(god.isAllowedContract(_target), "Contract not allowed in ChamberGod");
         require(!isAllowedContract(_target), "Contract already allowed");
 
@@ -337,7 +323,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @param _target The address of the allowedContract to remove
      */
-    function removeAllowedContract(address _target) external onlyManager {
+    function removeAllowedContract(address _target) external override onlyManager {
         require(isAllowedContract(_target), "Contract not allowed");
 
         allowedContracts.removeStorage(_target);
@@ -352,7 +338,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      *
      * @return bool True/False if the address is an allowedContract or not
      */
-    function isAllowedContract(address _target) public view returns (bool) {
+    function isAllowedContract(address _target) public view override returns (bool) {
         return allowedContracts.contains(_target);
     }
 
@@ -367,7 +353,12 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      * @param _recipient   The address of the recipient
      * @param _quantity    The quantity of the chamber to mint
      */
-    function mint(address _recipient, uint256 _quantity) external onlyWizard nonReentrant {
+    function mint(address _recipient, uint256 _quantity)
+        external
+        override
+        onlyWizard
+        nonReentrant
+    {
         _mint(_recipient, _quantity);
     }
 
@@ -378,7 +369,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      * @param _from          The address of the source to burn from
      * @param _quantity      The quantity of the chamber tokens to burn
      */
-    function burn(address _from, uint256 _quantity) external onlyWizard nonReentrant {
+    function burn(address _from, uint256 _quantity) external override onlyWizard nonReentrant {
         _burn(_from, _quantity);
     }
 
@@ -392,6 +383,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      */
     function withdrawTo(address _constituent, address _recipient, uint256 _quantity)
         external
+        override
         onlyWizard
     {
         if (_quantity > 0) {
@@ -418,7 +410,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
      * list. Used by wizards. E.g. after an uncollateralized mint in the streaming fee wizard .
      *
      */
-    function updateQuantities() external onlyWizard nonReentrant {
+    function updateQuantities() external override onlyWizard nonReentrant {
         uint256 totalSupply = IERC20(address(this)).totalSupply();
         uint256 decimals = ERC20(address(this)).decimals();
         for (uint256 i = 0; i < constituents.length; i++) {
@@ -453,7 +445,7 @@ contract Chamber is Owned, ReentrancyGuard, ERC20 {
         uint256 _minBuyQuantity,
         bytes memory _data,
         address payable _target
-    ) external onlyWizard returns (uint256 tokenAmountBought) {
+    ) external override onlyWizard returns (uint256 tokenAmountBought) {
         require(_target != address(this), "Cannot invoke the Chamber");
         require(isAllowedContract(_target), "Target not allowed");
         uint256 tokenAmountBefore = IERC20(_buyToken).balanceOf(address(this));

--- a/src/IssuerWizard.sol
+++ b/src/IssuerWizard.sol
@@ -109,7 +109,7 @@ contract IssuerWizard is ReentrancyGuard {
      */
     function redeem(IChamber _chamber, uint256 _quantity) external nonReentrant {
         require(_quantity > 0, "Quantity must be greater than 0");
-        uint256 currentBalance = _chamber.balanceOf(msg.sender);
+        uint256 currentBalance = IERC20(address(_chamber)).balanceOf(msg.sender);
         require(currentBalance >= _quantity, "Not enough balance to redeem");
 
         _chamber.burn(msg.sender, _quantity);

--- a/src/StreamingFeeWizard.sol
+++ b/src/StreamingFeeWizard.sol
@@ -299,7 +299,7 @@ contract StreamingFeeWizard is ReentrancyGuard {
         uint256 _streamingFeePercentage
     ) internal nonReentrant returns (uint256 inflationQuantity) {
         // Get chamber supply
-        uint256 currentSupply = IERC20(_chamber).totalSupply();
+        uint256 currentSupply = IERC20(address(_chamber)).totalSupply();
 
         // Calculate inflation quantity
         inflationQuantity = _calculateInflationQuantity(

--- a/src/interfaces/IChamber.sol
+++ b/src/interfaces/IChamber.sol
@@ -28,9 +28,7 @@
  */
 pragma solidity ^0.8.17.0;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-interface IChamber is IERC20 {
+interface IChamber {
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -46,6 +44,10 @@ interface IChamber is IERC20 {
     event WizardAdded(address indexed _wizard);
 
     event WizardRemoved(address indexed _wizard);
+
+    event AllowedContractAdded(address indexed _allowedContract);
+
+    event AllowedContractRemoved(address indexed _allowedContract);
 
     /*//////////////////////////////////////////////////////////////
                                CHAMBER MANAGEMENT

--- a/test/unit/IssuerWizard/issue.t.sol
+++ b/test/unit/IssuerWizard/issue.t.sol
@@ -109,9 +109,11 @@ contract IssuerWizardUnitIssueTest is Test {
 
         uint256 currentChamberBalance = IERC20(token1).balanceOf(chamberAddress);
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.balanceOf.selector, alice), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
+            abi.encode(0)
         );
-        assertEq(chamber.balanceOf(alice), 0);
+        assertEq(IERC20(address(chamber)).balanceOf(alice), 0);
         assertEq(currentChamberBalance, previousChamberBalance);
         assertEq(IERC20(token1).balanceOf(alice), requiredToken1Collateral);
     }
@@ -164,9 +166,11 @@ contract IssuerWizardUnitIssueTest is Test {
 
         uint256 currentChamberBalance = IERC20(token1).balanceOf(chamberAddress);
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.balanceOf.selector, alice), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
+            abi.encode(0)
         );
-        assertEq(chamber.balanceOf(alice), 0);
+        assertEq(IERC20(address(chamber)).balanceOf(alice), 0);
         assertEq(currentChamberBalance, previousChamberBalance);
         assertEq(IERC20(token1).balanceOf(alice), requiredToken1Collateral);
     }
@@ -219,9 +223,11 @@ contract IssuerWizardUnitIssueTest is Test {
 
         uint256 currentChamberBalance = IERC20(token1).balanceOf(chamberAddress);
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.balanceOf.selector, alice), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
+            abi.encode(0)
         );
-        assertEq(chamber.balanceOf(alice), 0);
+        assertEq(IERC20(address(chamber)).balanceOf(alice), 0);
         assertEq(currentChamberBalance, previousChamberBalance);
         assertEq(IERC20(token1).balanceOf(alice), requiredToken1Collateral - 1);
     }
@@ -288,9 +294,11 @@ contract IssuerWizardUnitIssueTest is Test {
         uint256 currentToken1ChamberBalance = IERC20(token1).balanceOf(chamberAddress);
         uint256 currentToken2ChamberBalance = IERC20(token2).balanceOf(chamberAddress);
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.balanceOf.selector, alice), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
+            abi.encode(0)
         );
-        assertEq(chamber.balanceOf(alice), 0);
+        assertEq(IERC20(address(chamber)).balanceOf(alice), 0);
         assertEq(currentToken1ChamberBalance, previousToken1ChamberBalance);
         assertEq(currentToken2ChamberBalance, previousToken2ChamberBalance);
         assertEq(IERC20(token1).balanceOf(alice), requiredToken1Collateral);
@@ -417,10 +425,10 @@ contract IssuerWizardUnitIssueTest is Test {
         uint256 currentChamberBalance = IERC20(token1).balanceOf(chamberAddress);
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, alice),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
             abi.encode(quantityToMint)
         );
-        assertEq(chamber.balanceOf(alice), quantityToMint);
+        assertEq(IERC20(address(chamber)).balanceOf(alice), quantityToMint);
         assertEq(currentChamberBalance, previousChamberBalance + requiredToken1Collateral);
         assertEq(IERC20(token1).balanceOf(alice), 0);
     }
@@ -500,10 +508,10 @@ contract IssuerWizardUnitIssueTest is Test {
         uint256 currentToken2ChamberBalance = IERC20(token2).balanceOf(chamberAddress);
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, alice),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
             abi.encode(quantityToMint)
         );
-        assertEq(chamber.balanceOf(alice), quantityToMint);
+        assertEq(IERC20(address(chamber)).balanceOf(alice), quantityToMint);
         assertEq(
             currentToken1ChamberBalance, previousToken1ChamberBalance + requiredToken1Collateral
         );

--- a/test/unit/IssuerWizard/redeem.t.sol
+++ b/test/unit/IssuerWizard/redeem.t.sol
@@ -62,18 +62,20 @@ contract IssuerWizardUnitRedeemTest is Test {
      */
     function testCannotRedeemQuantityZero() public {
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.totalSupply.selector), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
+            abi.encode(0)
         );
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, (address(this))),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, (address(this))),
             abi.encode(0)
         );
         uint256 previousChamberSupply = IERC20(chamberAddress).totalSupply();
         uint256 previousBalance = IERC20(chamberAddress).balanceOf(address(this));
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, (address(this))),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, (address(this))),
             abi.encode(0)
         );
         vm.expectRevert(bytes("Quantity must be greater than 0"));
@@ -81,11 +83,13 @@ contract IssuerWizardUnitRedeemTest is Test {
         issuerWizard.redeem(IChamber(chamberAddress), 0);
 
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.totalSupply.selector), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
+            abi.encode(0)
         );
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, (address(this))),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, (address(this))),
             abi.encode(0)
         );
         uint256 currentChamberSupply = IERC20(chamberAddress).totalSupply();
@@ -101,18 +105,20 @@ contract IssuerWizardUnitRedeemTest is Test {
     function testCannotRedeemQuantityIsLessThanBalance() public {
         uint256 quantityToRedeem = 20;
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.totalSupply.selector), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
+            abi.encode(0)
         );
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, (alice)),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, (alice)),
             abi.encode(quantityToRedeem - 1)
         );
         uint256 previousChamberSupply = IERC20(chamberAddress).totalSupply();
         uint256 previousAliceBalance = IERC20(chamberAddress).balanceOf(alice);
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, (alice)),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, (alice)),
             abi.encode(quantityToRedeem - 1)
         );
         vm.expectRevert(bytes("Not enough balance to redeem"));
@@ -121,11 +127,13 @@ contract IssuerWizardUnitRedeemTest is Test {
         issuerWizard.redeem(IChamber(chamberAddress), quantityToRedeem);
 
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.totalSupply.selector), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
+            abi.encode(0)
         );
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, (alice)),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, (alice)),
             abi.encode(quantityToRedeem - 1)
         );
         uint256 currentChamberSupply = IERC20(chamberAddress).totalSupply();
@@ -150,14 +158,14 @@ contract IssuerWizardUnitRedeemTest is Test {
 
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.totalSupply.selector),
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
             abi.encode(quantityToRedeem)
         );
-        uint256 previousChamberSupply = chamber.totalSupply();
+        uint256 previousChamberSupply = IERC20(address(chamber)).totalSupply();
 
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, alice),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
             abi.encode(quantityToRedeem)
         );
         vm.mockCall(
@@ -175,7 +183,7 @@ contract IssuerWizardUnitRedeemTest is Test {
             abi.encodeWithSelector(ERC20(address(chamber)).decimals.selector),
             abi.encode(18)
         );
-        vm.expectCall(chamberAddress, abi.encodeCall(chamber.balanceOf, (alice)));
+        vm.expectCall(chamberAddress, abi.encodeCall(IERC20(address(chamber)).balanceOf, (alice)));
         vm.expectCall(chamberAddress, abi.encodeCall(chamber.burn, (alice, quantityToRedeem)));
         vm.expectCall(chamberAddress, abi.encodeCall(chamber.getConstituentsAddresses, ()));
         vm.expectEmit(true, true, false, true, address(issuerWizard));
@@ -185,10 +193,14 @@ contract IssuerWizardUnitRedeemTest is Test {
         issuerWizard.redeem(chamber, quantityToRedeem);
 
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.totalSupply.selector), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
+            abi.encode(0)
         );
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.balanceOf.selector, alice), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
+            abi.encode(0)
         );
         uint256 currentChamberSupply = IERC20(chamberAddress).totalSupply();
         uint256 currentAliceBalance = IERC20(chamberAddress).balanceOf(alice);
@@ -209,14 +221,14 @@ contract IssuerWizardUnitRedeemTest is Test {
 
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.totalSupply.selector),
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
             abi.encode(quantityToRedeem)
         );
-        uint256 previousChamberSupply = chamber.totalSupply();
+        uint256 previousChamberSupply = IERC20(address(chamber)).totalSupply();
 
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, alice),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
             abi.encode(quantityToRedeem)
         );
         vm.mockCall(
@@ -263,10 +275,14 @@ contract IssuerWizardUnitRedeemTest is Test {
         issuerWizard.redeem(IChamber(chamberAddress), quantityToRedeem);
 
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.totalSupply.selector), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
+            abi.encode(0)
         );
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.balanceOf.selector, alice), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
+            abi.encode(0)
         );
         uint256 currentChamberSupply = IERC20(chamberAddress).totalSupply();
         uint256 currentAliceBalance = IERC20(chamberAddress).balanceOf(alice);
@@ -300,10 +316,10 @@ contract IssuerWizardUnitRedeemTest is Test {
 
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.totalSupply.selector),
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
             abi.encode(quantityToRedeem)
         );
-        uint256 previousChamberSupply = chamber.totalSupply();
+        uint256 previousChamberSupply = IERC20(address(chamber)).totalSupply();
         uint256 previousChamberToken1Balance = IERC20(token1).balanceOf(chamberAddress);
         uint256 previousChamberToken2Balance = IERC20(token2).balanceOf(chamberAddress);
         uint256 previousAliceToken1Balance = IERC20(token1).balanceOf(alice);
@@ -316,7 +332,7 @@ contract IssuerWizardUnitRedeemTest is Test {
 
         vm.mockCall(
             chamberAddress,
-            abi.encodeWithSelector(chamber.balanceOf.selector, alice),
+            abi.encodeWithSelector(IERC20(address(chamber)).balanceOf.selector, alice),
             abi.encode(quantityToRedeem)
         );
         vm.mockCall(
@@ -371,9 +387,11 @@ contract IssuerWizardUnitRedeemTest is Test {
         IERC20(token2).transfer(alice, requiredToken2Collateral);
 
         vm.mockCall(
-            chamberAddress, abi.encodeWithSelector(chamber.totalSupply.selector), abi.encode(0)
+            chamberAddress,
+            abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
+            abi.encode(0)
         );
-        uint256 currentChamberSupply = chamber.totalSupply();
+        uint256 currentChamberSupply = IERC20(address(chamber)).totalSupply();
         uint256 currentChamberToken1Balance = IERC20(token1).balanceOf(chamberAddress);
         uint256 currentChamberToken2Balance = IERC20(token2).balanceOf(chamberAddress);
         uint256 currentAliceToken1Balance = IERC20(token1).balanceOf(alice);


### PR DESCRIPTION
# Summary

- Now the Chamber contract inherits from the IChamber interface, also all the events and structs will be stored in the Interface