### PR TITLE
:art: remove redundant require statement at `createChamber` in ChamberGod

### DIFF
--- a/src/ChamberGod.sol
+++ b/src/ChamberGod.sol
@@ -81,7 +81,6 @@ contract ChamberGod is IChamberGod, Owned {
         address[] memory _managers
     ) external returns (address) {
         require(_constituents.length > 0, "Must have constituents");
-        require(_quantities.length > 0, "Must have quantities");
         require(_constituents.length == _quantities.length, "Elements lengths not equal");
         require(!_constituents.hasDuplicate(), "Constituents must be unique");
 

--- a/test/unit/ChamberGod/createChamber.t.sol
+++ b/test/unit/ChamberGod/createChamber.t.sol
@@ -118,7 +118,7 @@ contract ChamberGodUnitCreateChamberTest is Test {
         _managers = new address[](1);
         _managers[0] = address(owner);
         _wizards = new address[](0);
-        vm.expectRevert("Must have quantities");
+        vm.expectRevert("Elements lengths not equal");
         god.createChamber(_name, _symbol, _constituents, _quantities, _wizards, _managers);
     }
 


### PR DESCRIPTION
Closes #15 

### Summary:
- Remove redundant check.
- Update involved tests.