### PR TITLE
:art: `Chamber` Change unnecessary calls to itself, get state instead.

### DIFF
--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -400,13 +400,13 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      */
     function updateQuantities() external onlyWizard nonReentrant {
-        uint256 totalSupply = IERC20(address(this)).totalSupply();
-        uint256 decimals = ERC20(address(this)).decimals();
+        uint256 _totalSupply = totalSupply;
+        uint256 _decimals = decimals;
         for (uint256 i = 0; i < constituents.length; i++) {
             address _constituent = constituents[i];
 
             uint256 currentBalance = IERC20(_constituent).balanceOf(address(this));
-            uint256 _newQuantity = currentBalance.preciseDiv(totalSupply, decimals);
+            uint256 _newQuantity = currentBalance.preciseDiv(_totalSupply, _decimals);
 
             require(_newQuantity > 0, "Zero quantity not allowed");
 


### PR DESCRIPTION
Closes #17 

### Summary:
- Use supply and decimals Chamber state var instead of making an external call to the `Chamber` itself.