### PR TITLE
🎨  add `isChamber` check at issue/redeem function in `IssuerWizard`

### DIFF
--- a/.github/workflows/tests-audit-pocs.yml
+++ b/.github/workflows/tests-audit-pocs.yml
@@ -1,0 +1,14 @@
+name: Chamber Audit Pocs Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  audit-pocs-tests-chamber:
+    uses: ./.github/workflows/tests-template.yml
+    with:
+      make-command: test-audit-pocs-mainnet-fork
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test-chamber-integration-mainnet-fork :; FOUNDRY_FUZZ_RUNS=5 forge test --match-
 test-issuer-wizard-integration-mainnet-fork :; FOUNDRY_FUZZ_RUNS=5 forge test --match-path "./test/integration/IssuerWizard/*.sol" --fork-url https://eth-mainnet.g.alchemy.com/v2/$(ALCHEMY_ETH_API_KEY) --ffi -vvv
 test-rebalance-wizard-integration-mainnet-fork :; FOUNDRY_FUZZ_RUNS=5 forge test --match-path "./test/integration/RebalanceWizard/*.sol" --fork-url https://eth-mainnet.g.alchemy.com/v2/$(ALCHEMY_ETH_API_KEY) --ffi -vvv
 test-streaming-fee-wizard-integration-mainnet-fork :; FOUNDRY_FUZZ_RUNS=5 forge test --match-path "./test/integration/StreamingFeeWizard/*.sol" --fork-url https://eth-mainnet.g.alchemy.com/v2/$(ALCHEMY_ETH_API_KEY) --ffi -vvv
+test-audit-pocs-mainnet-fork :; FOUNDRY_FUZZ_RUNS=5 forge test --match-path "./test/audit/**/*.sol" --fork-url https://eth-mainnet.g.alchemy.com/v2/$(ALCHEMY_ETH_API_KEY) --ffi -vvv
 test-unit-mainnet-fork :; forge test --match-path "./test/unit/**/*.sol" --fork-url https://eth-mainnet.g.alchemy.com/v2/$(ALCHEMY_ETH_API_KEY) --ffi -vvv
 trace   :; forge test -vvv
 clean  :; forge clean

--- a/src/IssuerWizard.sol
+++ b/src/IssuerWizard.sol
@@ -35,10 +35,32 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {PreciseUnitMath} from "./lib/PreciseUnitMath.sol";
 import {IIssuerWizard} from "./interfaces/IIssuerWizard.sol";
+import {IChamberGod} from "./interfaces/IChamberGod.sol";
 
 contract IssuerWizard is IIssuerWizard, ReentrancyGuard {
+    /*//////////////////////////////////////////////////////////////
+                                 CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    IChamberGod private chamberGod;
+
+    /*//////////////////////////////////////////////////////////////
+                                 LIBRARIES
+    //////////////////////////////////////////////////////////////*/
+
     using SafeERC20 for IERC20;
     using PreciseUnitMath for uint256;
+
+    /*//////////////////////////////////////////////////////////////
+                               CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @param _chamberGod        Chamber God
+     */
+    constructor(address _chamberGod) {
+        chamberGod = IChamberGod(_chamberGod);
+    }
 
     /*//////////////////////////////////////////////////////////////
                                FUNCTIONS
@@ -75,6 +97,7 @@ contract IssuerWizard is IIssuerWizard, ReentrancyGuard {
      * @param _quantity Amount of Chamber tokens to be minted
      */
     function issue(IChamber _chamber, uint256 _quantity) external nonReentrant {
+        require(chamberGod.isChamber(address(_chamber)), "Target chamber not valid");
         require(_quantity > 0, "Quantity must be greater than 0");
 
         (address[] memory _constituents, uint256[] memory _requiredConstituentsQuantities) =
@@ -99,6 +122,7 @@ contract IssuerWizard is IIssuerWizard, ReentrancyGuard {
      * @param _quantity Amount of Chamber tokens to be burned
      */
     function redeem(IChamber _chamber, uint256 _quantity) external nonReentrant {
+        require(chamberGod.isChamber(address(_chamber)), "Target chamber not valid");
         require(_quantity > 0, "Quantity must be greater than 0");
         uint256 currentBalance = IERC20(address(_chamber)).balanceOf(msg.sender);
         require(currentBalance >= _quantity, "Not enough balance to redeem");

--- a/test/audit/Chambers.t.sol
+++ b/test/audit/Chambers.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17.0;
+
+import {Test} from "forge-std/Test.sol";
+import {ChamberGod} from "src/ChamberGod.sol";
+import {Chamber} from "src/Chamber.sol";
+import {IssuerWizard} from "src/IssuerWizard.sol";
+import {RebalanceWizard, IRebalanceWizard} from "src/RebalanceWizard.sol";
+import {StreamingFeeWizard, IStreamingFeeWizard} from "src/StreamingFeeWizard.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {console} from "forge-std/console.sol";
+
+contract FakeChamber {
+    function mint(address, uint256) external {
+        return;
+    }
+
+    function decimals() external view returns (uint8) {
+        return 18;
+    }
+
+    function getConstituentsAddresses() external view returns (address[] memory) {
+        address[] memory constituents = new address[](1);
+
+        // USDC
+        constituents[0] = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
+        return constituents;
+    }
+
+    function getConstituentQuantity(address) external view returns (uint256) {
+        return 1e18;
+    }
+}
+
+contract ChambersTest is Test {
+    uint256 public constant FORK_BLOCK_NUMBER = 16_421_844;
+
+    ERC20 public constant USDC = ERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+
+    ChamberGod public god;
+    IssuerWizard public issuer;
+    RebalanceWizard public rebalancer;
+    StreamingFeeWizard public fees;
+    Chamber public chamber;
+
+    address public owner;
+    address public manager;
+    address public bob;
+    address public alice;
+
+    function setUp() public {
+        //vm.createSelectFork(vm.rpcUrl("mainnet"), FORK_BLOCK_NUMBER);
+
+        owner = makeAddr("OWNER");
+        manager = makeAddr("MANAGER");
+        bob = makeAddr("BOB");
+        alice = makeAddr("ALICE");
+
+        vm.startPrank(owner);
+
+        //[ARCH] Moved god a few lines above because address is needed at IssuerWizard constructor
+        god = new ChamberGod();
+        issuer = new IssuerWizard(address(god));
+        rebalancer = new RebalanceWizard();
+        fees = new StreamingFeeWizard();
+
+        god.addWizard(address(issuer));
+        god.addWizard(address(rebalancer));
+        god.addWizard(address(fees));
+
+        address[] memory constituents = new address[](1);
+        constituents[0] = address(USDC);
+
+        uint256[] memory quantities = new uint256[](1);
+        quantities[0] = 1000e6;
+
+        address[] memory wizards = new address[](3);
+        wizards[0] = address(issuer);
+        wizards[1] = address(rebalancer);
+        wizards[2] = address(fees);
+
+        address[] memory managers = new address[](1);
+        managers[0] = manager;
+
+        chamber = Chamber(
+            god.createChamber("Nomoi USDC", "nUSDC", constituents, quantities, wizards, managers)
+        );
+
+        vm.stopPrank();
+
+        vm.startPrank(manager);
+        IStreamingFeeWizard.FeeState memory feeState =
+            IStreamingFeeWizard.FeeState(owner, 1e18, 1e18, block.timestamp);
+
+        fees.enableChamber(chamber, feeState);
+        vm.stopPrank();
+
+        deal(address(USDC), bob, 1000000e6);
+        deal(address(USDC), alice, 1000000e6);
+    }
+
+    function testCollectMultiple() public {
+        vm.startPrank(alice);
+
+        USDC.approve(address(issuer), type(uint256).max);
+        issuer.issue(chamber, 1e18);
+
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+
+        USDC.approve(address(issuer), type(uint256).max);
+        issuer.issue(chamber, 1e18);
+
+        vm.stopPrank();
+
+        console.log("Initial total supply", chamber.totalSupply());
+
+        for (uint256 i; i < 365; ++i) {
+            vm.warp(block.timestamp + 1 days);
+            fees.collectStreamingFee(chamber);
+        }
+
+        vm.warp(block.timestamp + 0.25 days);
+        fees.collectStreamingFee(chamber);
+
+        console.log("total supply", chamber.totalSupply());
+        console.log("time", block.timestamp);
+        console.log("fees received", chamber.balanceOf(owner));
+        console.log("chamber quantity", chamber.getConstituentQuantity(address(USDC)));
+    }
+
+    function testCollectOnce() public {
+        vm.startPrank(alice);
+
+        USDC.approve(address(issuer), type(uint256).max);
+        issuer.issue(chamber, 1e18);
+
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+
+        USDC.approve(address(issuer), type(uint256).max);
+        issuer.issue(chamber, 1e18);
+
+        vm.stopPrank();
+
+        console.log("Initial total supply", chamber.totalSupply());
+
+        vm.warp(block.timestamp + 365.25 days);
+        fees.collectStreamingFee(chamber);
+
+        console.log("total supply", chamber.totalSupply());
+        console.log("time", block.timestamp);
+        console.log("fees received", chamber.balanceOf(owner));
+        console.log("chamber quantity", chamber.getConstituentQuantity(address(USDC)));
+    }
+
+    function testIssueToFakeChamber() public {
+        FakeChamber fakeChamber = new FakeChamber();
+
+        //[ARCH] save Bob's USDC balance to check after the phishing attempt.
+        uint256 bobBalanceBeforePhishingAttempt = USDC.balanceOf(address(bob));
+
+        vm.startPrank(bob);
+
+        // Bob approves the issuer to use all USDC tokens
+        USDC.approve(address(issuer), type(uint256).max);
+        // Bob deposits into a legit chamber
+        issuer.issue(chamber, 1e6);
+        // Bob is the target of a phishing attack that makes him interact with a fake malicious
+        // chamber
+
+        //[ARCH] Should revert now because fakeChamber was not created by ChamberGod
+        vm.expectRevert("Target chamber not valid");
+        issuer.issue(Chamber(address(fakeChamber)), 1e6);
+
+        vm.stopPrank();
+
+        // The fake chamber stole Bob's tokens
+        // Depending on the implementation of `FakeChamber.getConstituentQuantity`, all USDC could
+        // be stolen from Bob
+
+        //[ARCH] Check that Assets were not stolen
+        assertEq(USDC.balanceOf(address(fakeChamber)), 0);
+
+        console.log("Bob USDC balance", USDC.balanceOf(address(bob)));
+        console.log("Issuer", USDC.balanceOf(address(fakeChamber)));
+        console.log("Fake chamber USDC balance", USDC.balanceOf(address(issuer)));
+    }
+}

--- a/test/integration/Chamber/updateQuantities.t.sol
+++ b/test/integration/Chamber/updateQuantities.t.sol
@@ -53,7 +53,7 @@ contract ChamberIntegrationUpdateQuantitiesTest is Test {
         globalQuantities[0] = 6 ether;
         globalQuantities[1] = 2 ether;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         evilSaruman = new EvilSaruman();

--- a/test/integration/Chamber/updateQuantities.t.sol
+++ b/test/integration/Chamber/updateQuantities.t.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.17.0;
 import "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IChamber} from "src/interfaces/IChamber.sol";
+import {IChamberGod} from "src/interfaces/IChamberGod.sol";
 import {Chamber} from "src/Chamber.sol";
 import {IssuerWizard} from "src/IssuerWizard.sol";
 import {ChamberFactory} from "test/utils/factories.sol";
@@ -181,6 +182,15 @@ contract ChamberIntegrationUpdateQuantitiesTest is Test {
         vm.expectEmit(true, true, true, true, issuerAddress);
         emit ChamberTokenIssued(address(chamber), aliceTheSorcerer, initialSupply);
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
+
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(chamber)), initialSupply);
 
@@ -250,6 +260,15 @@ contract ChamberIntegrationUpdateQuantitiesTest is Test {
 
         vm.expectEmit(true, true, true, true, issuerAddress);
         emit ChamberTokenIssued(address(chamber), aliceTheSorcerer, initialSupply);
+
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
 
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(chamber)), initialSupply);
@@ -327,6 +346,15 @@ contract ChamberIntegrationUpdateQuantitiesTest is Test {
         vm.expectEmit(true, true, true, true, issuerAddress);
         emit ChamberTokenIssued(address(chamber), aliceTheSorcerer, initialSupply);
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
+
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(chamber)), initialSupply);
 
@@ -393,6 +421,15 @@ contract ChamberIntegrationUpdateQuantitiesTest is Test {
 
         vm.expectEmit(true, true, true, true, issuerAddress);
         emit ChamberTokenIssued(address(chamber), aliceTheSorcerer, initialSupply);
+
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
 
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(chamber)), initialSupply);

--- a/test/integration/IssuerWizard/getConstituentsQuantitiesForIssuance.t.sol
+++ b/test/integration/IssuerWizard/getConstituentsQuantitiesForIssuance.t.sol
@@ -41,7 +41,7 @@ contract IssuerWizardIntegrationGetConstituentsQuantitiesForIssuanceTest is Test
         globalQuantities[0] = 1;
         globalQuantities[1] = 2;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         address[] memory wizards = new address[](1);

--- a/test/integration/IssuerWizard/issue.t.sol
+++ b/test/integration/IssuerWizard/issue.t.sol
@@ -43,7 +43,7 @@ contract IssuerWizardIntegrationIssueTest is Test {
         globalQuantities[0] = 1;
         globalQuantities[1] = 2;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         address[] memory wizards = new address[](1);

--- a/test/integration/IssuerWizard/redeem.t.sol
+++ b/test/integration/IssuerWizard/redeem.t.sol
@@ -45,7 +45,7 @@ contract IssuerWizardIntegrationRedeemTest is Test {
         globalQuantities[0] = 1;
         globalQuantities[1] = 2;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         address[] memory wizards = new address[](1);

--- a/test/integration/RebalanceWizard/rebalance.t.sol
+++ b/test/integration/RebalanceWizard/rebalance.t.sol
@@ -25,7 +25,7 @@ contract RebalanceWizardIntegrationRebalanceTest is ChamberTestUtils {
                               VARIABLES
     //////////////////////////////////////////////////////////////*/
 
-    IChamber chamber;
+    IChamber private chamber;
     IssuerWizard private issuer;
     RebalanceWizard private rebalancer;
     ChamberGod private god;
@@ -45,10 +45,6 @@ contract RebalanceWizardIntegrationRebalanceTest is ChamberTestUtils {
     //////////////////////////////////////////////////////////////*/
 
     function setUp() public {
-        issuer = new IssuerWizard();
-        rebalancer = new RebalanceWizard();
-        vm.label(address(issuer), "Issuer");
-        vm.label(address(rebalancer), "Rebalancer");
         constituents = new address[](1);
         quantities = new uint256[](1);
         wizards = new address[](2);
@@ -56,6 +52,10 @@ contract RebalanceWizardIntegrationRebalanceTest is ChamberTestUtils {
         owner = vm.addr(0x2);
         vm.startPrank(owner);
         god = new ChamberGod();
+        issuer = new IssuerWizard(address(god));
+        rebalancer = new RebalanceWizard();
+        vm.label(address(issuer), "Issuer");
+        vm.label(address(rebalancer), "Rebalancer");
         god.addWizard(address(issuer));
         god.addWizard(address(rebalancer));
         wizards[0] = address(issuer);

--- a/test/integration/RebalanceWizard/trade.t.sol
+++ b/test/integration/RebalanceWizard/trade.t.sol
@@ -52,10 +52,6 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
     //////////////////////////////////////////////////////////////*/
 
     function setUp() public {
-        issuer = new IssuerWizard();
-        rebalancer = new ExposedRebalanceWizard();
-        vm.label(address(issuer), "Issuer");
-        vm.label(address(rebalancer), "Rebalancer");
         constituents = new address[](1);
         quantities = new uint256[](1);
         wizards = new address[](2);
@@ -63,6 +59,10 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
         owner = vm.addr(0x2);
         vm.startPrank(owner);
         god = new ChamberGod();
+        issuer = new IssuerWizard(address(god));
+        rebalancer = new ExposedRebalanceWizard();
+        vm.label(address(issuer), "Issuer");
+        vm.label(address(rebalancer), "Rebalancer");
         god.addWizard(address(issuer));
         god.addWizard(address(rebalancer));
         wizards[0] = address(issuer);

--- a/test/integration/StreamingFeeWizard/_collectStreamingFee.t.sol
+++ b/test/integration/StreamingFeeWizard/_collectStreamingFee.t.sol
@@ -53,7 +53,7 @@ contract StreamingFeeWizardIntegrationInternalCollectStreamingFeeTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new ExposedStreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/_collectStreamingFee.t.sol
+++ b/test/integration/StreamingFeeWizard/_collectStreamingFee.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IChamber} from "src/interfaces/IChamber.sol";
+import {IChamberGod} from "src/interfaces/IChamberGod.sol";
 import {IssuerWizard} from "src/IssuerWizard.sol";
 import {Chamber} from "src/Chamber.sol";
 import {ChamberFactory} from "test/utils/factories.sol";
@@ -142,6 +143,15 @@ contract StreamingFeeWizardIntegrationInternalCollectStreamingFeeTest is Test {
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(someChamber)
+            ),
+            abi.encode(true)
+        );
+
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(someChamber)), initialSupply);
 
@@ -230,6 +240,15 @@ contract StreamingFeeWizardIntegrationInternalCollectStreamingFeeTest is Test {
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamberAddress)
+            ),
+            abi.encode(true)
+        );
+
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(chamberAddress), initialSupply);
 
@@ -304,6 +323,15 @@ contract StreamingFeeWizardIntegrationInternalCollectStreamingFeeTest is Test {
         IERC20(token1).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[0], 18));
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
+
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamberAddress)
+            ),
+            abi.encode(true)
+        );
 
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(chamberAddress), initialSupply);

--- a/test/integration/StreamingFeeWizard/collectStreamingFee.t.sol
+++ b/test/integration/StreamingFeeWizard/collectStreamingFee.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IChamber} from "src/interfaces/IChamber.sol";
+import {IChamberGod} from "src/interfaces/IChamberGod.sol";
 import {IssuerWizard} from "src/IssuerWizard.sol";
 import {Chamber} from "src/Chamber.sol";
 import {ChamberFactory} from "test/utils/factories.sol";
@@ -148,6 +149,15 @@ contract StreamingFeeWizardIntegrationCollectStreamingFeeTest is Test {
 
         vm.warp(block.timestamp + 300000); // Let time pass to accumulate fees
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(someChamber)
+            ),
+            abi.encode(true)
+        );
+
         vm.expectRevert(bytes("Must be a wizard"));
         streamingFeeWizard.collectStreamingFee(IChamber(address(someChamber)));
 
@@ -173,6 +183,15 @@ contract StreamingFeeWizardIntegrationCollectStreamingFeeTest is Test {
         IERC20(token1).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[0], 18));
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
+
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamberAddress)
+            ),
+            abi.encode(true)
+        );
 
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(chamberAddress), initialSupply);
@@ -244,6 +263,15 @@ contract StreamingFeeWizardIntegrationCollectStreamingFeeTest is Test {
         IERC20(token1).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[0], 18));
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
+
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(someChamber)
+            ),
+            abi.encode(true)
+        );
 
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(someChamber)), initialSupply);
@@ -359,6 +387,15 @@ contract StreamingFeeWizardIntegrationCollectStreamingFeeTest is Test {
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamberAddress)
+            ),
+            abi.encode(true)
+        );
+
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(chamberAddress), initialSupply);
 
@@ -456,7 +493,16 @@ contract StreamingFeeWizardIntegrationCollectStreamingFeeTest is Test {
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(someChamber)
+            ),
+            abi.encode(true)
+        );
         vm.prank(aliceTheSorcerer);
+
         issuerWizard.issue(IChamber(address(someChamber)), initialSupply);
 
         // Time passes

--- a/test/integration/StreamingFeeWizard/collectStreamingFee.t.sol
+++ b/test/integration/StreamingFeeWizard/collectStreamingFee.t.sol
@@ -56,7 +56,7 @@ contract StreamingFeeWizardIntegrationCollectStreamingFeeTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new ExposedStreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/enableArchChamber.t.sol
+++ b/test/integration/StreamingFeeWizard/enableArchChamber.t.sol
@@ -41,7 +41,7 @@ contract StreamingFeeWizardIntegrationEnableChamberTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new StreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/getFeeState.t.sol
+++ b/test/integration/StreamingFeeWizard/getFeeState.t.sol
@@ -40,7 +40,7 @@ contract StreamingFeeWizardIntegrationGetFeeStateTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new StreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/getLastCollectTimestamp.t.sol
+++ b/test/integration/StreamingFeeWizard/getLastCollectTimestamp.t.sol
@@ -40,7 +40,7 @@ contract StreamingFeeWizardIntegrationGetLastCollectTimestampTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new StreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/getMaxStreamingFee.t.sol
+++ b/test/integration/StreamingFeeWizard/getMaxStreamingFee.t.sol
@@ -40,7 +40,7 @@ contract StreamingFeeWizardIntegrationGetMaxStreamingFeeTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new StreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/getStreamingFeePercentage.t.sol
+++ b/test/integration/StreamingFeeWizard/getStreamingFeePercentage.t.sol
@@ -40,7 +40,7 @@ contract StreamingFeeWizardIntegrationGetStreamingFeePercentageTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new StreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/getStreamingFeeRecipient.t.sol
+++ b/test/integration/StreamingFeeWizard/getStreamingFeeRecipient.t.sol
@@ -40,7 +40,7 @@ contract StreamingFeeWizardIntegrationGetStreamingFeeRecipientTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new StreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/updateFeeRecipient.t.sol
+++ b/test/integration/StreamingFeeWizard/updateFeeRecipient.t.sol
@@ -47,7 +47,7 @@ contract StreamingFeeWizardIntegrationUpdateFeeRecipientTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new StreamingFeeWizard();

--- a/test/integration/StreamingFeeWizard/updateStreamingFee.t.sol
+++ b/test/integration/StreamingFeeWizard/updateStreamingFee.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IChamber} from "src/interfaces/IChamber.sol";
+import {IChamberGod} from "src/interfaces/IChamberGod.sol";
 import {IssuerWizard} from "src/IssuerWizard.sol";
 import {Chamber} from "src/Chamber.sol";
 import {ChamberFactory} from "test/utils/factories.sol";
@@ -165,6 +166,15 @@ contract StreamingFeeWizardIntegrationUpdateStreamingFeeTest is Test {
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamberAddress)
+            ),
+            abi.encode(true)
+        );
+
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(chamberAddress)), initialSupply);
 
@@ -220,6 +230,15 @@ contract StreamingFeeWizardIntegrationUpdateStreamingFeeTest is Test {
         IERC20(token1).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[0], 18));
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
+
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(someChamber)
+            ),
+            abi.encode(true)
+        );
 
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(someChamber)), initialSupply);
@@ -343,6 +362,15 @@ contract StreamingFeeWizardIntegrationUpdateStreamingFeeTest is Test {
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
 
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(someChamber)
+            ),
+            abi.encode(true)
+        );
+
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(someChamber)), initialSupply);
 
@@ -436,6 +464,15 @@ contract StreamingFeeWizardIntegrationUpdateStreamingFeeTest is Test {
         IERC20(token1).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[0], 18));
         vm.prank(aliceTheSorcerer);
         IERC20(token2).approve(issuerAddress, initialSupply.preciseMulCeil(globalQuantities[1], 18));
+
+        // Mock Call to simulate that the Chamber Has been Created by ChamberGod
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamberAddress)
+            ),
+            abi.encode(true)
+        );
 
         vm.prank(aliceTheSorcerer);
         issuerWizard.issue(IChamber(address(chamberAddress)), initialSupply);

--- a/test/integration/StreamingFeeWizard/updateStreamingFee.t.sol
+++ b/test/integration/StreamingFeeWizard/updateStreamingFee.t.sol
@@ -57,7 +57,7 @@ contract StreamingFeeWizardIntegrationUpdateStreamingFeeTest is Test {
         globalQuantities[0] = 54;
         globalQuantities[1] = 77;
 
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         issuerAddress = address(issuerWizard);
 
         streamingFeeWizard = new ExposedStreamingFeeWizard();

--- a/test/unit/IssuerWizard/getConstituentsQuantitiesForIssuance.t.sol
+++ b/test/unit/IssuerWizard/getConstituentsQuantitiesForIssuance.t.sol
@@ -33,7 +33,7 @@ contract IssuerWizardUnitGetConstituentsQuantitiesForIssuanceTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function setUp() public {
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         chamber = IChamber(chamberAddress);
         issuerAddress = address(issuerWizard);
         vm.label(chamberGodAddress, "ChamberGod");

--- a/test/unit/IssuerWizard/issue.t.sol
+++ b/test/unit/IssuerWizard/issue.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IChamber} from "src/interfaces/IChamber.sol";
+import {IChamberGod} from "src/interfaces/IChamberGod.sol";
 import {IIssuerWizard} from "src/interfaces/IIssuerWizard.sol";
 import {IssuerWizard} from "src/IssuerWizard.sol";
 import {PreciseUnitMath} from "src/lib/PreciseUnitMath.sol";
@@ -36,7 +37,7 @@ contract IssuerWizardUnitIssueTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function setUp() public {
-        issuerWizard = new IssuerWizard();
+        issuerWizard = new IssuerWizard(chamberGodAddress);
         chamber = IChamber(chamberAddress);
         issuerAddress = address(issuerWizard);
         vm.label(chamberGodAddress, "ChamberGod");
@@ -56,9 +57,32 @@ contract IssuerWizardUnitIssueTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     /**
-     * [REVERT] Calling issue() should revert if quantity is zero
+     * [REVERT] Calling issue() should revert if the chamber is not in the chambers list at
+     * chamberGod.
+     */
+    function testCannotIssueChamberNotCreatedByGod() public {
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(false)
+        );
+        vm.expectRevert(bytes("Target chamber not valid"));
+        issuerWizard.issue(IChamber(chamberAddress), 0);
+    }
+
+    /**
+     * [REVERT] Calling issue() should revert if quantity is zero.
      */
     function testCannotIssueQuantityZero() public {
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
         vm.expectRevert(bytes("Quantity must be greater than 0"));
         issuerWizard.issue(IChamber(chamberAddress), 0);
     }
@@ -95,6 +119,13 @@ contract IssuerWizardUnitIssueTest is Test {
             chamberAddress,
             abi.encodeWithSelector(chamber.getConstituentQuantity.selector, token1),
             abi.encode(token1Quantity)
+        );
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
         );
         vm.expectCall(
             token1,
@@ -153,6 +184,13 @@ contract IssuerWizardUnitIssueTest is Test {
             abi.encodeWithSelector(chamber.getConstituentQuantity.selector, token1),
             abi.encode(token1Quantity)
         );
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
         vm.expectCall(
             token1,
             abi.encodeCall(
@@ -209,6 +247,13 @@ contract IssuerWizardUnitIssueTest is Test {
             chamberAddress,
             abi.encodeWithSelector(chamber.getConstituentQuantity.selector, token1),
             abi.encode(token1Quantity)
+        );
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
         );
         vm.expectCall(
             token1,
@@ -278,6 +323,13 @@ contract IssuerWizardUnitIssueTest is Test {
             abi.encodeWithSelector(chamber.getConstituentQuantity.selector, token2),
             abi.encode(token2Quantity)
         );
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
         vm.expectCall(
             token1,
             abi.encodeCall(
@@ -326,6 +378,13 @@ contract IssuerWizardUnitIssueTest is Test {
             abi.encodeWithSelector(ERC20(address(chamber)).decimals.selector),
             abi.encode(18)
         );
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
         vm.expectCall(chamberAddress, abi.encodeCall(chamber.mint, (address(this), quantityToMint)));
         vm.expectEmit(true, true, true, true, address(issuerWizard));
         emit ChamberTokenIssued(chamberAddress, address(this), quantityToMint);
@@ -358,6 +417,13 @@ contract IssuerWizardUnitIssueTest is Test {
             chamberAddress,
             abi.encodeWithSelector(chamber.getConstituentQuantity.selector, token2),
             abi.encode(0)
+        );
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
         );
         vm.expectCall(
             address(token1),
@@ -404,6 +470,13 @@ contract IssuerWizardUnitIssueTest is Test {
             chamberAddress,
             abi.encodeWithSelector(chamber.getConstituentQuantity.selector, token1),
             abi.encode(token1Quantity)
+        );
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
         );
         vm.expectCall(
             token1,
@@ -478,6 +551,13 @@ contract IssuerWizardUnitIssueTest is Test {
             chamberAddress,
             abi.encodeWithSelector(chamber.getConstituentQuantity.selector, token2),
             abi.encode(token2Quantity)
+        );
+        vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
         );
         vm.expectCall(
             token1,


### PR DESCRIPTION
Closes #18 

### Summary:

- ChamberGod address is now part of `IssuerWizard` constructor.
- The target Chamber for issue/redeem external functions at `IssuerWizard` must have been created but the corresponding ChamberGod. 
- Updated Integration and Unit involved tests.
- Created a folder for Audit pocs to check if the findings are solved.
- Added audit-pocs testing to GH workflows.