### PR TITLE
:lock:nonReentrant modifier for external functions

### DIFF
--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -137,7 +137,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _constituent The address of the constituent to add
      */
-    function addConstituent(address _constituent) external onlyWizard {
+    function addConstituent(address _constituent) external onlyWizard nonReentrant {
         require(!isConstituent(_constituent), "Must not be constituent");
 
         constituents.push(_constituent);
@@ -150,7 +150,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _constituent The address of the constituent to remove
      */
-    function removeConstituent(address _constituent) external onlyWizard {
+    function removeConstituent(address _constituent) external onlyWizard nonReentrant {
         require(isConstituent(_constituent), "Must be constituent");
 
         constituents.removeStorage(_constituent);
@@ -196,7 +196,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _manager The address of the manager to add
      */
-    function addManager(address _manager) external onlyOwner {
+    function addManager(address _manager) external onlyOwner nonReentrant {
         require(!isManager(_manager), "Already manager");
         require(_manager != address(0), "Cannot add null address");
 
@@ -210,7 +210,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _manager The address of the manager to remove
      */
-    function removeManager(address _manager) external onlyOwner {
+    function removeManager(address _manager) external onlyOwner nonReentrant {
         require(isManager(_manager), "Not a manager");
 
         managers.removeStorage(_manager);
@@ -223,7 +223,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _wizard The address of the wizard to add
      */
-    function addWizard(address _wizard) external onlyManager {
+    function addWizard(address _wizard) external onlyManager nonReentrant {
         require(god.isWizard(_wizard), "Wizard not validated in ChamberGod");
         require(!isWizard(_wizard), "Wizard already in Chamber");
 
@@ -237,7 +237,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _wizard The address of the wizard to remove
      */
-    function removeWizard(address _wizard) external onlyManager {
+    function removeWizard(address _wizard) external onlyManager nonReentrant {
         require(isWizard(_wizard), "Wizard not in chamber");
 
         wizards.removeStorage(_wizard);
@@ -313,7 +313,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _target The address of the allowedContract to add
      */
-    function addAllowedContract(address _target) external onlyManager {
+    function addAllowedContract(address _target) external onlyManager nonReentrant {
         require(god.isAllowedContract(_target), "Contract not allowed in ChamberGod");
         require(!isAllowedContract(_target), "Contract already allowed");
 
@@ -327,7 +327,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      *
      * @param _target The address of the allowedContract to remove
      */
-    function removeAllowedContract(address _target) external onlyManager {
+    function removeAllowedContract(address _target) external onlyManager nonReentrant {
         require(isAllowedContract(_target), "Contract not allowed");
 
         allowedContracts.removeStorage(_target);
@@ -462,7 +462,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
         uint256 _minBuyQuantity,
         bytes memory _data,
         address payable _target
-    ) external onlyWizard returns (uint256 tokenAmountBought) {
+    ) external onlyWizard nonReentrant returns (uint256 tokenAmountBought) {
         require(_target != address(this), "Cannot invoke the Chamber");
         require(isAllowedContract(_target), "Target not allowed");
         uint256 tokenAmountBefore = IERC20(_buyToken).balanceOf(address(this));

--- a/src/ChamberGod.sol
+++ b/src/ChamberGod.sol
@@ -29,11 +29,12 @@
 pragma solidity ^0.8.17.0;
 
 import {Owned} from "solmate/auth/Owned.sol";
+import {ReentrancyGuard} from "solmate/utils/ReentrancyGuard.sol";
 import {ArrayUtils} from "./lib/ArrayUtils.sol";
 import {Chamber} from "./Chamber.sol";
 import {IChamberGod} from "./interfaces/IChamberGod.sol";
 
-contract ChamberGod is IChamberGod, Owned {
+contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
     /*//////////////////////////////////////////////////////////////
                               LIBRARIES
     //////////////////////////////////////////////////////////////*/
@@ -79,7 +80,7 @@ contract ChamberGod is IChamberGod, Owned {
         uint256[] memory _quantities,
         address[] memory _wizards,
         address[] memory _managers
-    ) external returns (address) {
+    ) external nonReentrant returns (address) {
         require(_constituents.length > 0, "Must have constituents");
         require(_constituents.length == _quantities.length, "Elements lengths not equal");
         require(!_constituents.hasDuplicate(), "Constituents must be unique");
@@ -159,7 +160,7 @@ contract ChamberGod is IChamberGod, Owned {
      *
      * @param _wizard    The address of the Wizard to add
      */
-    function addWizard(address _wizard) external onlyOwner {
+    function addWizard(address _wizard) external onlyOwner nonReentrant {
         require(_wizard != address(0), "Must be a valid wizard");
         require(!isWizard(address(_wizard)), "Wizard already in ChamberGod");
 
@@ -173,7 +174,7 @@ contract ChamberGod is IChamberGod, Owned {
      *
      * @param _wizard    The address of the Wizard to remove
      */
-    function removeWizard(address _wizard) external onlyOwner {
+    function removeWizard(address _wizard) external onlyOwner nonReentrant {
         require(isWizard(_wizard), "Wizard not valid");
 
         wizards.removeStorage(_wizard);
@@ -195,7 +196,7 @@ contract ChamberGod is IChamberGod, Owned {
      *
      * @param _target    The address of the allowed contract to add
      */
-    function addAllowedContract(address _target) external onlyOwner {
+    function addAllowedContract(address _target) external onlyOwner nonReentrant {
         require(!isAllowedContract(_target), "Contract already allowed");
 
         allowedContracts.push(_target);
@@ -208,7 +209,7 @@ contract ChamberGod is IChamberGod, Owned {
      *
      * @param _target    The address of the allowed contract to remove
      */
-    function removeAllowedContract(address _target) external onlyOwner {
+    function removeAllowedContract(address _target) external onlyOwner nonReentrant {
         require(isAllowedContract(_target), "Contract not allowed");
 
         allowedContracts.removeStorage(_target);

--- a/src/StreamingFeeWizard.sol
+++ b/src/StreamingFeeWizard.sol
@@ -62,7 +62,7 @@ contract StreamingFeeWizard is IStreamingFeeWizard, ReentrancyGuard {
      * @param _chamber  Chamber to enable
      * @param _feeState     First feeState of the Chamber
      */
-    function enableChamber(IChamber _chamber, FeeState memory _feeState) external {
+    function enableChamber(IChamber _chamber, FeeState memory _feeState) external nonReentrant {
         require(IChamber(_chamber).isManager(msg.sender), "msg.sender is not chamber's manager");
         require(_feeState.feeRecipient != address(0), "Recipient cannot be null address");
         require(_feeState.maxStreamingFeePercentage <= 100 * SCALE_UNIT, "Max fee must be <= 100%");
@@ -82,7 +82,7 @@ contract StreamingFeeWizard is IStreamingFeeWizard, ReentrancyGuard {
      *
      * @param _chamber Chamber to acquire streaming fees from
      */
-    function collectStreamingFee(IChamber _chamber) external {
+    function collectStreamingFee(IChamber _chamber) external nonReentrant {
         uint256 previousCollectTimestamp = feeStates[_chamber].lastCollectTimestamp;
         require(previousCollectTimestamp > 0, "Chamber does not exist");
         require(previousCollectTimestamp < block.timestamp, "Cannot collect twice");
@@ -105,7 +105,10 @@ contract StreamingFeeWizard is IStreamingFeeWizard, ReentrancyGuard {
      * @param _chamber          Chamber to update streaming fee percentage
      * @param _newFeePercentage     New streaming fee in percentage [1 % = 10e18]
      */
-    function updateStreamingFee(IChamber _chamber, uint256 _newFeePercentage) external {
+    function updateStreamingFee(IChamber _chamber, uint256 _newFeePercentage)
+        external
+        nonReentrant
+    {
         uint256 previousCollectTimestamp = feeStates[_chamber].lastCollectTimestamp;
         require(previousCollectTimestamp > 0, "Chamber does not exist");
         require(previousCollectTimestamp < block.timestamp, "Cannot update fee after collecting");
@@ -138,7 +141,10 @@ contract StreamingFeeWizard is IStreamingFeeWizard, ReentrancyGuard {
      * @param _chamber          Chamber to update max. streaming fee percentage
      * @param _newMaxFeePercentage  New max. streaming fee in percentage [1 % = 10e18]
      */
-    function updateMaxStreamingFee(IChamber _chamber, uint256 _newMaxFeePercentage) external {
+    function updateMaxStreamingFee(IChamber _chamber, uint256 _newMaxFeePercentage)
+        external
+        nonReentrant
+    {
         require(feeStates[_chamber].lastCollectTimestamp > 0, "Chamber does not exist");
         require(IChamber(_chamber).isManager(msg.sender), "msg.sender is not chamber's manager");
         require(
@@ -162,7 +168,10 @@ contract StreamingFeeWizard is IStreamingFeeWizard, ReentrancyGuard {
      * @param _chamber          Chamber to update streaming fee recipient
      * @param _newFeeRecipient      New fee recipient address
      */
-    function updateFeeRecipient(IChamber _chamber, address _newFeeRecipient) external {
+    function updateFeeRecipient(IChamber _chamber, address _newFeeRecipient)
+        external
+        nonReentrant
+    {
         require(feeStates[_chamber].lastCollectTimestamp > 0, "Chamber does not exist");
         require(IChamber(_chamber).isManager(msg.sender), "msg.sender is not chamber's manager");
         require(_newFeeRecipient != address(0), "Recipient cannot be null address");
@@ -278,7 +287,7 @@ contract StreamingFeeWizard is IStreamingFeeWizard, ReentrancyGuard {
         IChamber _chamber,
         uint256 _lastCollectTimestamp,
         uint256 _streamingFeePercentage
-    ) internal nonReentrant returns (uint256 inflationQuantity) {
+    ) internal returns (uint256 inflationQuantity) {
         // Get chamber supply
         uint256 currentSupply = IERC20(address(_chamber)).totalSupply();
 


### PR DESCRIPTION
Closes #12 

### Summary:
- Add missing `nonReentrant` modifier at every external function.