### PR TITLE
:sparkles: Add enhancements

### DIFF
--- a/scripts/fetch-full-0x-quote.js
+++ b/scripts/fetch-full-0x-quote.js
@@ -14,7 +14,7 @@ async function main(amount, sellToken, buyToken){
   try{
     const response = await axios.get(quoteUrl)
     const {data} = response
-    const encodedData = encoder.encode(["bytes", "uint256", "address"], [data.data, data.buyAmount, data.to])
+    const encodedData = encoder.encode(["bytes", "uint256", "address", "address"], [data.data, data.buyAmount, data.to, data.allowanceTarget])
     process.stdout.write(encodedData)
   } catch(error) {
     console.log(error)

--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -424,6 +424,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      * @param _minBuyQuantity     The minimum amount of buyToken that should be bought
      * @param _data               The data to be passed to the contract
      * @param _target            The address of the contract to call
+     * @param _allowanceTarget    The address of the contract to give allowance of tokens
      *
      * @return tokenAmountBought  The amount of buyToken bought
      */
@@ -433,23 +434,28 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
         address _buyToken,
         uint256 _minBuyQuantity,
         bytes memory _data,
-        address payable _target
+        address payable _target,
+        address _allowanceTarget
     ) external onlyWizard returns (uint256 tokenAmountBought) {
         require(_target != address(this), "Cannot invoke the Chamber");
         require(isAllowedContract(_target), "Target not allowed");
         uint256 tokenAmountBefore = IERC20(_buyToken).balanceOf(address(this));
-        uint256 currentAllowance = IERC20(_sellToken).allowance(address(this), _target);
+        uint256 currentAllowance = IERC20(_sellToken).allowance(address(this), _allowanceTarget);
 
         if (currentAllowance < _sellQuantity) {
             IERC20(_sellToken).safeIncreaseAllowance(
-                _target, ((_sellQuantity * 105 / 100) - currentAllowance)
+                _allowanceTarget, (_sellQuantity - currentAllowance)
             );
         }
         _invokeContract(_data, _target);
 
+        currentAllowance = IERC20(_sellToken).allowance(address(this), _allowanceTarget);
+        IERC20(_sellToken).safeDecreaseAllowance(_allowanceTarget, currentAllowance);
+
         uint256 tokenAmountAfter = IERC20(_buyToken).balanceOf(address(this));
         tokenAmountBought = tokenAmountAfter - tokenAmountBefore;
         require(tokenAmountBought >= _minBuyQuantity, "Underbought buy quantity");
+
         return tokenAmountBought;
     }
 

--- a/src/RebalanceWizard.sol
+++ b/src/RebalanceWizard.sol
@@ -93,7 +93,8 @@ contract RebalanceWizard is ReentrancyGuard, IRebalanceWizard {
             params._buyToken,
             params._minBuyQuantity,
             params._data,
-            params._target
+            params._target,
+            params._allowanceTarget
         );
 
         params._chamber.updateQuantities();

--- a/src/interfaces/IChamber.sol
+++ b/src/interfaces/IChamber.sol
@@ -103,6 +103,7 @@ interface IChamber {
         address _buyToken,
         uint256 _minBuyQuantity,
         bytes memory _data,
-        address payable _target
+        address payable _target,
+        address _allowanceTarget
     ) external returns (uint256 tokenAmountBought);
 }

--- a/src/interfaces/IRebalanceWizard.sol
+++ b/src/interfaces/IRebalanceWizard.sol
@@ -41,6 +41,7 @@ interface IRebalanceWizard {
         uint256 _sellQuantity;
         address _buyToken;
         uint256 _minBuyQuantity;
+        address _allowanceTarget;
         address payable _target;
         bytes _data;
     }

--- a/test/integration/RebalanceWizard/rebalance.t.sol
+++ b/test/integration/RebalanceWizard/rebalance.t.sol
@@ -110,16 +110,23 @@ contract RebalanceWizardIntegrationRebalanceTest is ChamberTestUtils {
 
         data = abi.encodeWithSignature("withdraw(uint256)", sharesToSell);
         IRebalanceWizard.RebalanceParams memory withdrawParams = IRebalanceWizard.RebalanceParams(
-            chamber, yvUSDC, sharesToSell, usdc, expectedUSDC, payable(yvUSDC), data
+            chamber, yvUSDC, sharesToSell, usdc, expectedUSDC, yvUSDC, payable(yvUSDC), data
         );
         trades[0] = withdrawParams;
 
         // Data for the second trade (Swap in 0x USDC for USDT)
-        (bytes memory quotes, uint256 buyAmount, address target) =
-            getCompleteQuoteData(usdc, expectedUSDC, usdt);
+        CompleteQuoteResponse memory response =
+            getCompleteQuoteData(CompleteQuoteParams(usdc, expectedUSDC, usdt));
 
         IRebalanceWizard.RebalanceParams memory swapParams = IRebalanceWizard.RebalanceParams(
-            chamber, usdc, expectedUSDC, usdt, buyAmount, payable(target), quotes
+            chamber,
+            usdc,
+            expectedUSDC,
+            usdt,
+            response._buyAmount,
+            response._allowanceTarget,
+            payable(response._target),
+            response._quotes
         );
         trades[1] = swapParams;
 
@@ -130,18 +137,25 @@ contract RebalanceWizardIntegrationRebalanceTest is ChamberTestUtils {
         require(success, "Failed to get pricePerShare");
 
         price = abi.decode(result, (uint256));
-        uint256 expectedShares = buyAmount.preciseDiv(price, 6);
+        uint256 expectedShares = response._buyAmount.preciseDiv(price, 6);
         expectedShares = expectedShares * 995 / 1000;
 
-        data = abi.encodeWithSignature("deposit(uint256)", buyAmount);
+        data = abi.encodeWithSignature("deposit(uint256)", response._buyAmount);
         IRebalanceWizard.RebalanceParams memory depositParams = IRebalanceWizard.RebalanceParams(
-            chamber, usdt, buyAmount, yvUSDT, expectedShares, payable(yvUSDT), data
+            chamber,
+            usdt,
+            response._buyAmount,
+            yvUSDT,
+            expectedShares,
+            yvUSDT,
+            payable(yvUSDT),
+            data
         );
         trades[2] = depositParams;
 
         vm.startPrank(owner);
-        god.addAllowedContract(target);
-        chamber.addAllowedContract(target);
+        god.addAllowedContract(response._target);
+        chamber.addAllowedContract(response._target);
         rebalancer.rebalance(trades);
         vm.stopPrank();
     }

--- a/test/integration/RebalanceWizard/trade.t.sol
+++ b/test/integration/RebalanceWizard/trade.t.sol
@@ -109,7 +109,7 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
         god.addAllowedContract(target);
         chamberWithNoVault.addAllowedContract(target);
         params = IRebalanceWizard.RebalanceParams(
-            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.expectRevert();
         rebalancer.trade(params);
@@ -133,7 +133,7 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
         god.addAllowedContract(target);
         chamberWithNoVault.addAllowedContract(target);
         params = IRebalanceWizard.RebalanceParams(
-            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.expectRevert("Sell quantity >= chamber balance");
         rebalancer.trade(params);
@@ -150,7 +150,7 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
         address target = vm.addr(0x123123);
         vm.startPrank(owner);
         params = IRebalanceWizard.RebalanceParams(
-            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.expectRevert("Target not allowed");
         rebalancer.trade(params);
@@ -169,7 +169,7 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
         god.addAllowedContract(target);
         chamberWithNoVault.addAllowedContract(target);
         params = IRebalanceWizard.RebalanceParams(
-            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.expectRevert("Cannot invoke the Chamber");
         rebalancer.trade(params);
@@ -188,7 +188,7 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
         god.addAllowedContract(target);
         chamberWithNoVault.addAllowedContract(target);
         params = IRebalanceWizard.RebalanceParams(
-            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.expectRevert("Sell quantity >= chamber balance");
         rebalancer.trade(params);
@@ -206,13 +206,20 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
     function testTradeUsing0xAggregator(uint256 sellAmount) public {
         vm.assume(sellAmount > 1e6);
         vm.assume(sellAmount < 100000e6);
-        (bytes memory quotes, uint256 buyAmount, address target) =
-            getCompleteQuoteData(usdc, sellAmount, dai);
+        CompleteQuoteResponse memory response =
+            getCompleteQuoteData(CompleteQuoteParams(usdc, sellAmount, dai));
         vm.startPrank(owner);
-        god.addAllowedContract(target);
-        chamberWithNoVault.addAllowedContract(target);
+        god.addAllowedContract(response._target);
+        chamberWithNoVault.addAllowedContract(response._target);
         params = IRebalanceWizard.RebalanceParams(
-            chamberWithNoVault, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamberWithNoVault,
+            usdc,
+            sellAmount,
+            dai,
+            response._buyAmount,
+            response._allowanceTarget,
+            payable(response._target),
+            response._quotes
         );
         rebalancer.trade(params);
         uint256 daiQty = chamberWithNoVault.getConstituentQuantity(dai);
@@ -244,6 +251,7 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
             depositAmount,
             yvUSDC,
             yvUSDCQty * 995 / 1000,
+            yvUSDC,
             payable(yvUSDC),
             data
         );
@@ -273,7 +281,14 @@ contract RebalanceWizardIntegrationTradeTest is ChamberTestUtils {
 
         data = abi.encodeWithSignature("withdraw(uint256)", sharesToSell);
         params = IRebalanceWizard.RebalanceParams(
-            chamberWithVault, yvUSDC, sharesToSell, usdc, expectedUSDC, payable(yvUSDC), data
+            chamberWithVault,
+            yvUSDC,
+            sharesToSell,
+            usdc,
+            expectedUSDC,
+            yvUSDC,
+            payable(yvUSDC),
+            data
         );
 
         rebalancer.trade(params);

--- a/test/unit/Chamber/executeTrade.t.sol
+++ b/test/unit/Chamber/executeTrade.t.sol
@@ -77,7 +77,7 @@ contract ChamberUnitExecuteTradeTest is ChamberTestUtils {
      */
     function testCannotExecuteTradeIfNotWizard() public {
         vm.expectRevert("Must be a wizard");
-        chamber.executeTrade(token1, 100 ether, token2, 0, bytes("0x1234"), dexAgg);
+        chamber.executeTrade(token1, 100 ether, token2, 0, bytes("0x1234"), dexAgg, dexAgg);
     }
 
     /**
@@ -100,7 +100,7 @@ contract ChamberUnitExecuteTradeTest is ChamberTestUtils {
 
         vm.expectRevert("Underbought buy quantity");
         vm.prank(wizard);
-        chamber.executeTrade(token1, 1 ether, token2, 1 ether, bytes("0x1234"), dexAgg);
+        chamber.executeTrade(token1, 1 ether, token2, 1 ether, bytes("0x1234"), dexAgg, dexAgg);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -134,6 +134,6 @@ contract ChamberUnitExecuteTradeTest is ChamberTestUtils {
         vm.expectCall(dexAgg, bytes("0x1234"));
 
         vm.prank(wizard);
-        chamber.executeTrade(token1, 1 ether, token2, 0, bytes("0x1234"), dexAgg);
+        chamber.executeTrade(token1, 1 ether, token2, 0, bytes("0x1234"), dexAgg, dexAgg);
     }
 }

--- a/test/unit/RebalanceWizard/trade.t.sol
+++ b/test/unit/RebalanceWizard/trade.t.sol
@@ -62,7 +62,7 @@ contract RebalanceWizardUnitTradeTest is ChamberTestUtils {
         bytes memory quotes = bytes(abi.encode(buyAmount));
         address target = vm.addr(0x123123);
         params = IRebalanceWizard.RebalanceParams(
-            chamber, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamber, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.mockCall(
             chamberAddress,
@@ -82,7 +82,7 @@ contract RebalanceWizardUnitTradeTest is ChamberTestUtils {
         bytes memory quotes = bytes(abi.encode(buyAmount));
         address target = vm.addr(0x123123);
         params = IRebalanceWizard.RebalanceParams(
-            chamber, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamber, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.expectRevert("Sell quantity must be > 0");
         vm.prank(owner);
@@ -98,7 +98,7 @@ contract RebalanceWizardUnitTradeTest is ChamberTestUtils {
         bytes memory quotes = bytes(abi.encode(buyAmount));
         address target = vm.addr(0x123123);
         params = IRebalanceWizard.RebalanceParams(
-            chamber, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamber, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.mockCall(
             chamberAddress,
@@ -123,7 +123,7 @@ contract RebalanceWizardUnitTradeTest is ChamberTestUtils {
         bytes memory quotes = bytes(abi.encode(buyAmount));
         address target = vm.addr(0x123123);
         params = IRebalanceWizard.RebalanceParams(
-            chamber, usdc, sellAmount, dai, buyAmount, payable(target), quotes
+            chamber, usdc, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.expectRevert("Min. buy quantity must be > 0");
         vm.prank(owner);
@@ -139,7 +139,7 @@ contract RebalanceWizardUnitTradeTest is ChamberTestUtils {
         bytes memory quotes = bytes(abi.encode(buyAmount));
         address target = vm.addr(0x123123);
         params = IRebalanceWizard.RebalanceParams(
-            chamber, usdc, sellAmount, usdc, buyAmount, payable(target), quotes
+            chamber, usdc, sellAmount, usdc, buyAmount, target, payable(target), quotes
         );
         vm.expectRevert("Traded tokens must be different");
         vm.prank(owner);
@@ -155,7 +155,7 @@ contract RebalanceWizardUnitTradeTest is ChamberTestUtils {
         bytes memory quotes = bytes(abi.encode(buyAmount));
         address target = vm.addr(0x123123);
         params = IRebalanceWizard.RebalanceParams(
-            chamber, yvUSDC, sellAmount, dai, buyAmount, payable(target), quotes
+            chamber, yvUSDC, sellAmount, dai, buyAmount, target, payable(target), quotes
         );
         vm.mockCall(
             chamberAddress,

--- a/test/utils/ChamberTestUtils.sol
+++ b/test/utils/ChamberTestUtils.sol
@@ -6,6 +6,23 @@ import "forge-std/Test.sol";
 
 contract ChamberTestUtils is Test {
     /*//////////////////////////////////////////////////////////////
+                              STRUCTS
+    //////////////////////////////////////////////////////////////*/
+
+    struct CompleteQuoteParams {
+        address _sellToken;
+        uint256 _sellAmount;
+        address _buyToken;
+    }
+
+    struct CompleteQuoteResponse {
+        bytes _quotes;
+        uint256 _buyAmount;
+        address _target;
+        address _allowanceTarget;
+    }
+
+    /*//////////////////////////////////////////////////////////////
                               INTERNAL
     //////////////////////////////////////////////////////////////*/
 
@@ -81,19 +98,19 @@ contract ChamberTestUtils is Test {
         return (quotesResponse[0], buyAmountResponse);
     }
 
-    function getCompleteQuoteData(address _sellToken, uint256 _sellAmount, address _buyToken)
+    function getCompleteQuoteData(CompleteQuoteParams memory _params)
         internal
-        returns (bytes memory, uint256, address)
+        returns (CompleteQuoteResponse memory)
     {
         string[] memory inputs = new string[](5);
         inputs[0] = "node";
         inputs[1] = "scripts/fetch-full-0x-quote.js";
-        inputs[2] = bytesToHex(abi.encode(_sellAmount));
-        inputs[3] = bytesToHex(abi.encode(address(_sellToken)));
-        inputs[4] = bytesToHex(abi.encode(_buyToken));
+        inputs[2] = bytesToHex(abi.encode(_params._sellAmount));
+        inputs[3] = bytesToHex(abi.encode(_params._sellToken));
+        inputs[4] = bytesToHex(abi.encode(_params._buyToken));
         bytes memory response = vm.ffi(inputs);
-        (bytes memory quotesResponse, uint256 sellAmountResponse, address target) =
-            abi.decode(response, (bytes, uint256, address));
-        return (quotesResponse, sellAmountResponse, target);
+        (bytes memory quotesResponse, uint256 buyAmount, address target, address allowanceTarget) =
+            abi.decode(response, (bytes, uint256, address, address));
+        return CompleteQuoteResponse(quotesResponse, buyAmount, target, allowanceTarget);
     }
 }


### PR DESCRIPTION
Closes #13 
Closes #14 
Closes #16 

# Summary 
- Remove `* 105 / 100` margin from sellAmount in `executeTrade`
- Add `IERC20(_sellToken).safeDecreaseAllowance(_allowanceTarget, currentAllowance);` to reset allowance after a trade
- Add `address _allowanceTarget` to support specifying a different allowance target than target to be called