### PR TITLE
🔒 Fix redeem rounding errors

### DIFF
--- a/src/IssuerWizard.sol
+++ b/src/IssuerWizard.sol
@@ -45,12 +45,12 @@ contract IssuerWizard is IIssuerWizard, ReentrancyGuard {
     //////////////////////////////////////////////////////////////*/
 
     /**
-     * Returns the amount of tokens required
+     * Returns the amount of tokens required for mint
      *
      * @param _chamber  Chamber instance
-     * @param _quantity Amount of Chamber tokens to be minted
+     * @param _mintQuantity Amount of Chamber tokens to be minted
      */
-    function getConstituentsQuantitiesForIssuance(IChamber _chamber, uint256 _quantity)
+    function getConstituentsQuantitiesForIssuance(IChamber _chamber, uint256 _mintQuantity)
         public
         view
         returns (address[] memory, uint256[] memory)
@@ -62,7 +62,31 @@ contract IssuerWizard is IIssuerWizard, ReentrancyGuard {
 
         for (uint256 i = 0; i < _numberOfConstituents; i++) {
             _requiredConstituentsQuantities[i] = _chamber.getConstituentQuantity(_constituents[i])
-                .preciseMulCeil(_quantity, chamberDecimals);
+                .preciseMulCeil(_mintQuantity, chamberDecimals);
+        }
+        return (_constituents, _requiredConstituentsQuantities);
+    }
+    
+    /**
+     * Returns the amount of tokens returned for redeem
+     *
+     * @param _chamber  Chamber instance
+     * @param _redeemQuantity Amount of Chamber tokens to be redeemed
+     */
+    function getConstituentsQuantitiesForRedeem(IChamber _chamber, uint256 _redeemQuantity)
+        public
+        view
+        returns (address[] memory, uint256[] memory)
+    {
+        address[] memory _constituents = _chamber.getConstituentsAddresses();
+        uint256 _numberOfConstituents = _constituents.length;
+        uint256[] memory _requiredConstituentsQuantities = new uint256[](_numberOfConstituents);
+        uint256 chamberDecimals = ERC20(address(_chamber)).decimals();
+
+        for (uint256 i = 0; i < _numberOfConstituents; i++) {
+            _requiredConstituentsQuantities[i] = _chamber.getConstituentQuantity(_constituents[i])
+                .preciseMul(_redeemQuantity, chamberDecimals);
+            require(_requiredConstituentsQuantities[i] > 0, "Redeem amount too low");
         }
         return (_constituents, _requiredConstituentsQuantities);
     }
@@ -106,7 +130,7 @@ contract IssuerWizard is IIssuerWizard, ReentrancyGuard {
         _chamber.burn(msg.sender, _quantity);
 
         (address[] memory _constituents, uint256[] memory _requiredConstituentsQuantities) =
-            getConstituentsQuantitiesForIssuance(_chamber, _quantity);
+            getConstituentsQuantitiesForRedeem(_chamber, _quantity);
 
         for (uint256 i = 0; i < _constituents.length; i++) {
             address constituent = _constituents[i];

--- a/src/IssuerWizard.sol
+++ b/src/IssuerWizard.sol
@@ -88,7 +88,7 @@ contract IssuerWizard is IIssuerWizard, ReentrancyGuard {
         }
         return (_constituents, _requiredConstituentsQuantities);
     }
-    
+
     /**
      * Returns the amount of tokens returned for redeem
      *

--- a/src/interfaces/IIssuerWizard.sol
+++ b/src/interfaces/IIssuerWizard.sol
@@ -45,7 +45,12 @@ interface IIssuerWizard {
                                 FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    function getConstituentsQuantitiesForIssuance(IChamber chamber, uint256 quantity)
+    function getConstituentsQuantitiesForIssuance(IChamber chamber, uint256 mintQuantity)
+        external
+        view
+        returns (address[] memory, uint256[] memory);
+
+    function getConstituentsQuantitiesForRedeem(IChamber chamber, uint256 redeemQuantity)
         external
         view
         returns (address[] memory, uint256[] memory);

--- a/test/integration/IssuerWizard/redeem.t.sol
+++ b/test/integration/IssuerWizard/redeem.t.sol
@@ -27,6 +27,7 @@ contract IssuerWizardIntegrationRedeemTest is Test {
     address public chamberGodAddress = vm.addr(0x791782394);
     address public token1 = 0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39; // HEX on ETH
     address public token2 = 0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e; // YFI on ETH
+    address public usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;   // USDC on ETH
     address[] public globalConstituents = new address[](2);
     uint256[] public globalQuantities = new uint256[](2);
 
@@ -115,6 +116,138 @@ contract IssuerWizardIntegrationRedeemTest is Test {
         assertEq(currentAliceBalance, previousAliceBalance);
     }
 
+    /**
+     * [REVERT] Cannor redeem tokens without receiving at least 1 wei of every constituents,
+     * when all constituents have zero as quantity. This scenario should not occur thanks
+     * to validations in other contracts.
+     */
+    function testCannotRedeemTokensWithZeroQuantityInContituents(uint256 quantityToRedeem)
+        public
+    {
+        vm.assume(quantityToRedeem > 0);
+        uint256[] memory testQuantities = new uint256[](2);
+        testQuantities[0] = 0;
+        testQuantities[1] = 0;
+
+        Chamber chamber =
+            chamberFactory.getChamberWithCustomTokens(globalConstituents, testQuantities);
+        vm.prank(alice);
+        issuerWizard.issue(IChamber(address(chamber)), quantityToRedeem);
+        assertEq(IERC20(address(chamber)).totalSupply(), quantityToRedeem);
+
+        vm.expectCall(address(chamber), abi.encodeCall(chamber.burn, (alice, quantityToRedeem)));
+        vm.expectCall(address(chamber), abi.encodeCall(chamber.getConstituentsAddresses, ()));
+
+        // Cannot redeem when trying to extract less than 1 wei of a constituent from the chamber (zero in this case)
+        vm.prank(alice);
+        vm.expectRevert(bytes("Redeem amount too low"));
+        issuerWizard.redeem(IChamber(address(chamber)), quantityToRedeem);
+
+        assertEq(IERC20(address(chamber)).totalSupply(), quantityToRedeem);
+        assertEq(IERC20(address(chamber)).balanceOf(alice), quantityToRedeem);
+    }
+
+    /**
+     * [REVERT] Should revert because the amount of redemption is not enough to get at least 1 wei of
+     * some constituent out of the chamber
+     */
+    function testCannotRedeemWithTwoConstituentsWhenAmountIsTooLow(
+        uint256 quantityToRedeem,
+        uint256 token1Quantity,
+        uint256 token2Quantity
+    ) public {
+        vm.assume(token1Quantity > 0);
+        vm.assume(token1Quantity < 1 ether);
+        vm.assume(token2Quantity > 0);
+        vm.assume(token2Quantity < 1 ether);
+        vm.assume(quantityToRedeem > 0);
+        vm.assume(quantityToRedeem < 1 ether);
+
+        uint256[] memory testQuantities = new uint256[](2);
+        testQuantities[0] = token1Quantity;
+        testQuantities[1] = token2Quantity;
+        uint256 requiredToken1Collateral = quantityToRedeem.preciseMulCeil(token1Quantity, 18);
+        uint256 requiredToken2Collateral = quantityToRedeem.preciseMulCeil(token2Quantity, 18);
+        deal(token1, alice, requiredToken1Collateral);
+        deal(token2, alice, requiredToken2Collateral);
+        assertEq(IERC20(token1).balanceOf(address(alice)), requiredToken1Collateral);
+        assertEq(IERC20(token2).balanceOf(address(alice)), requiredToken2Collateral);
+
+        Chamber chamber =
+            chamberFactory.getChamberWithCustomTokens(globalConstituents, testQuantities);
+        vm.prank(alice);
+        ERC20(token1).approve(issuerAddress, requiredToken1Collateral);
+        vm.prank(alice);
+        ERC20(token2).approve(issuerAddress, requiredToken2Collateral);
+
+        vm.prank(alice);
+        issuerWizard.issue(IChamber(address(chamber)), quantityToRedeem);
+
+        assertEq(chamber.totalSupply(), quantityToRedeem);
+        assertEq(IERC20(token1).balanceOf(address(alice)), 0);
+        assertEq(IERC20(token2).balanceOf(address(alice)), 0);
+        assertEq(IERC20(token1).balanceOf(address(chamber)), requiredToken1Collateral);
+        assertEq(IERC20(token2).balanceOf(address(chamber)), requiredToken2Collateral);
+
+        vm.prank(alice);
+        vm.expectRevert(bytes("Redeem amount too low"));
+        issuerWizard.redeem(IChamber(address(chamber)), quantityToRedeem);
+
+        assertEq(chamber.totalSupply(), quantityToRedeem);
+        assertGe(IERC20(token1).balanceOf(address(chamber)), requiredToken1Collateral);
+        assertGe(IERC20(token2).balanceOf(address(chamber)), requiredToken2Collateral);
+        assertGe(IERC20(token1).balanceOf(address(alice)), 0);
+        assertGe(IERC20(token2).balanceOf(address(alice)), 0);
+    }
+
+    /**
+     * [REVERT] Should revert because the minted amount was performed with FULL overcollateralization. In
+     * other words, all USDC put in the chamber is over-collateral, not legit-collateral. So every redeem
+     * amount will fail, as its not enough to get even 1 wei of USDC out.
+     */
+    function testCannotRedeemUSDCWhenMintWasOvercollateralized(
+        uint256 quantityToMint,
+        uint256 quantityToRedeem,
+        uint256 requiredUsdc
+    ) public {
+        vm.assume(requiredUsdc > 0);
+        vm.assume(requiredUsdc < 1 ether);
+        vm.assume(quantityToMint > 0);
+        vm.assume(quantityToMint < 1 ether / requiredUsdc); // Limit of full overcollateralization
+        vm.assume(quantityToRedeem > 0);
+        vm.assume(quantityToRedeem < quantityToMint);
+
+        address[] memory usdcAsConstituent = new address[](1);
+        usdcAsConstituent[0] = usdc;
+        uint256[] memory usdcQuantity = new uint256[](1);
+        usdcQuantity[0] = requiredUsdc;
+        uint256 requiredUsdcCollateral = quantityToMint.preciseMulCeil(requiredUsdc, 18);
+
+        deal(usdc, alice, requiredUsdcCollateral);
+        assertEq(IERC20(usdc).balanceOf(address(alice)), requiredUsdcCollateral);
+
+        Chamber chamber =
+            chamberFactory.getChamberWithCustomTokens(usdcAsConstituent, usdcQuantity);
+        vm.prank(alice);
+        ERC20(usdc).approve(issuerAddress, requiredUsdcCollateral);
+
+        // This is a forced mint, as the quantityToMint is less than 1e18, so we enter over-collateralization terriroty
+        vm.prank(alice);
+        issuerWizard.issue(IChamber(address(chamber)), quantityToMint);
+        assertEq(chamber.totalSupply(), quantityToMint);
+        assertEq(IERC20(usdc).balanceOf(address(alice)), 0);
+        assertEq(IERC20(usdc).balanceOf(address(chamber)), requiredUsdcCollateral);
+
+        // Every attempt to redeem should fail, because the mint was overcollaterized, so the redeemAmount is not enough to get even 1 wei of USDC out
+        vm.prank(alice);
+        vm.expectRevert(bytes("Redeem amount too low"));
+        issuerWizard.redeem(IChamber(address(chamber)), quantityToRedeem);
+
+        assertEq(chamber.totalSupply(), quantityToMint);
+        assertGe(IERC20(usdc).balanceOf(address(chamber)), requiredUsdcCollateral);
+        assertGe(IERC20(usdc).balanceOf(address(alice)), 0);
+    }
+
     /*//////////////////////////////////////////////////////////////
                               SUCCESS
     //////////////////////////////////////////////////////////////*/
@@ -152,41 +285,6 @@ contract IssuerWizardIntegrationRedeemTest is Test {
     }
 
     /**
-     * [SUCESS] Should burn an *infinite* amount of tokens without receiving any constituents,
-     * when all constituents have zero as quantity. This scenario should not occur thanks
-     * to validations in other contracts.
-     */
-    function testRedeemBurnInfiniteTokensWithZeroQuantityInContituents(uint256 quantityToRedeem)
-        public
-    {
-        vm.assume(quantityToRedeem > 0);
-        uint256[] memory testQuantities = new uint256[](2);
-        testQuantities[0] = 0;
-        testQuantities[1] = 0;
-
-        Chamber chamber =
-            chamberFactory.getChamberWithCustomTokens(globalConstituents, testQuantities);
-        vm.prank(alice);
-        issuerWizard.issue(IChamber(address(chamber)), quantityToRedeem);
-        uint256 previousChamberSupply = chamber.totalSupply();
-
-        vm.expectCall(address(chamber), abi.encodeCall(chamber.burn, (alice, quantityToRedeem)));
-        vm.expectCall(address(chamber), abi.encodeCall(chamber.getConstituentsAddresses, ()));
-        vm.expectEmit(true, true, false, true, address(chamber));
-        emit Transfer(alice, address(0x0), quantityToRedeem);
-        vm.expectEmit(true, true, false, true, address(issuerWizard));
-        emit ChamberTokenRedeemed(address(chamber), alice, quantityToRedeem);
-        vm.prank(alice);
-        issuerWizard.redeem(IChamber(address(chamber)), quantityToRedeem);
-
-        uint256 currentChamberSupply = IERC20(address(chamber)).totalSupply();
-        uint256 currentAliceBalance = IERC20(address(chamber)).balanceOf(alice);
-
-        assertEq(currentChamberSupply, previousChamberSupply - quantityToRedeem);
-        assertEq(currentAliceBalance, 0);
-    }
-
-    /**
      * [SUCCESS] Should return the constituents to the msg.sender when the redeem() function
      * is executed under normal circumstances.
      */
@@ -195,12 +293,12 @@ contract IssuerWizardIntegrationRedeemTest is Test {
         uint256 token1Quantity,
         uint256 token2Quantity
     ) public {
-        vm.assume(quantityToRedeem > 0);
-        vm.assume(quantityToRedeem < type(uint160).max);
         vm.assume(token1Quantity > 0);
-        vm.assume(token1Quantity < type(uint64).max);
+        vm.assume(token1Quantity < 1 ether);
         vm.assume(token2Quantity > 0);
-        vm.assume(token2Quantity < type(uint64).max);
+        vm.assume(token2Quantity < 1 ether);
+        vm.assume(quantityToRedeem > 1 ether);
+        vm.assume(quantityToRedeem < type(uint160).max);
 
         uint256[] memory testQuantities = new uint256[](2);
         testQuantities[0] = token1Quantity;
@@ -218,39 +316,78 @@ contract IssuerWizardIntegrationRedeemTest is Test {
         ERC20(token1).approve(issuerAddress, requiredToken1Collateral);
         vm.prank(alice);
         ERC20(token2).approve(issuerAddress, requiredToken2Collateral);
+
         vm.prank(alice);
         issuerWizard.issue(IChamber(address(chamber)), quantityToRedeem);
-        uint256 previousChamberSupply = chamber.totalSupply();
-        uint256 previousChamberToken1Balance = IERC20(token1).balanceOf(address(chamber));
-        uint256 previousChamberToken2Balance = IERC20(token2).balanceOf(address(chamber));
-        uint256 previousAliceToken1Balance = IERC20(token1).balanceOf(address(alice));
-        uint256 previousAliceToken2Balance = IERC20(token2).balanceOf(address(alice));
-        assertEq(previousChamberSupply, quantityToRedeem);
-        assertEq(previousAliceToken1Balance, 0);
-        assertEq(previousAliceToken2Balance, 0);
-        assertEq(previousChamberToken1Balance, requiredToken1Collateral);
-        assertEq(previousChamberToken2Balance, requiredToken2Collateral);
+
+        assertEq(chamber.totalSupply(), quantityToRedeem);
+        assertEq(IERC20(token1).balanceOf(address(alice)), 0);
+        assertEq(IERC20(token2).balanceOf(address(alice)), 0);
+        assertEq(IERC20(token1).balanceOf(address(chamber)), requiredToken1Collateral);
+        assertEq(IERC20(token2).balanceOf(address(chamber)), requiredToken2Collateral);
         vm.expectEmit(true, true, false, true, address(chamber));
         emit Transfer(alice, address(0x0), quantityToRedeem);
         vm.expectEmit(true, true, false, true, token1);
-        emit Transfer(address(chamber), alice, requiredToken1Collateral);
+        emit Transfer(address(chamber), alice, quantityToRedeem.preciseMul(token1Quantity, 18));
         vm.expectEmit(true, true, false, true, token2);
-        emit Transfer(address(chamber), alice, requiredToken2Collateral);
+        emit Transfer(address(chamber), alice, quantityToRedeem.preciseMul(token2Quantity, 18));
         vm.expectEmit(true, true, false, true, address(issuerWizard));
         emit ChamberTokenRedeemed(address(chamber), alice, quantityToRedeem);
 
         vm.prank(alice);
         issuerWizard.redeem(IChamber(address(chamber)), quantityToRedeem);
 
-        uint256 currentChamberSupply = chamber.totalSupply();
-        uint256 currentChamberToken1Balance = IERC20(token1).balanceOf(address(chamber));
-        uint256 currentChamberToken2Balance = IERC20(token2).balanceOf(address(chamber));
-        uint256 currentAliceToken1Balance = IERC20(token1).balanceOf(address(alice));
-        uint256 currentAliceToken2Balance = IERC20(token2).balanceOf(address(alice));
-        assertEq(currentChamberSupply, 0);
-        assertEq(currentAliceToken1Balance, requiredToken1Collateral);
-        assertEq(currentAliceToken2Balance, requiredToken2Collateral);
-        assertEq(currentChamberToken1Balance, 0);
-        assertEq(currentChamberToken2Balance, 0);
+        assertEq(chamber.totalSupply(), 0);
+        assertGe(IERC20(token1).balanceOf(address(chamber)), quantityToRedeem.preciseMulCeil(token1Quantity, 18) - quantityToRedeem.preciseMul(token1Quantity, 18));
+        assertGe(IERC20(token2).balanceOf(address(chamber)), quantityToRedeem.preciseMulCeil(token2Quantity, 18) - quantityToRedeem.preciseMul(token2Quantity, 18));
+        assertGe(IERC20(token1).balanceOf(address(alice)), quantityToRedeem.preciseMul(token1Quantity, 18));
+        assertGe(IERC20(token2).balanceOf(address(alice)), quantityToRedeem.preciseMul(token2Quantity, 18));
+    }
+
+    /**
+     * [SUCCESS] Should be able to redeem some USDC, because some part of the mint was not
+     * overcollateralized, in other words, was legit collateralization, not a bonus.
+     */
+    function testRedeemUSDCWithGeneralMintUseCase(
+        uint256 quantityToMint,
+        uint256 quantityToRedeem,
+        uint256 requiredUsdc
+    ) public {
+        vm.assume(requiredUsdc > 0);
+        vm.assume(requiredUsdc < 1 ether);
+        vm.assume(quantityToMint >= 1 ether);
+        vm.assume(quantityToMint < type(uint128).max);
+        vm.assume(quantityToRedeem > 1 ether / requiredUsdc); // Limit of legit collateral
+        vm.assume(quantityToRedeem <= quantityToMint);
+
+        address[] memory usdcAsConstituent = new address[](1);
+        usdcAsConstituent[0] = usdc;
+        uint256[] memory usdcQuantity = new uint256[](1);
+        usdcQuantity[0] = requiredUsdc;
+        uint256 requiredUsdcCollateral = quantityToMint.preciseMulCeil(requiredUsdc, 18);
+
+        deal(usdc, alice, requiredUsdcCollateral);
+        assertEq(IERC20(usdc).balanceOf(address(alice)), requiredUsdcCollateral);
+
+        Chamber chamber =
+            chamberFactory.getChamberWithCustomTokens(usdcAsConstituent, usdcQuantity);
+        vm.prank(alice);
+        ERC20(usdc).approve(issuerAddress, requiredUsdcCollateral);
+
+        // This is not a forced mint, at least 1e18 chamber tokens will be collaterizaed in a legit manner, while the rest is a combination of
+        // legit collateralization and overcollateralization
+        vm.prank(alice);
+        issuerWizard.issue(IChamber(address(chamber)), quantityToMint);
+        assertEq(chamber.totalSupply(), quantityToMint);
+        assertEq(IERC20(usdc).balanceOf(address(alice)), 0);
+        assertEq(IERC20(usdc).balanceOf(address(chamber)), requiredUsdcCollateral);
+
+        // Every redeem will pass, as the user will be able to get some USDC out
+        vm.prank(alice);
+        issuerWizard.redeem(IChamber(address(chamber)), quantityToRedeem);
+
+        assertEq(chamber.totalSupply(), quantityToMint - quantityToRedeem);
+        assertEq(IERC20(usdc).balanceOf(address(chamber)), requiredUsdcCollateral - quantityToRedeem.preciseMul(requiredUsdc, 18));
+        assertEq(IERC20(usdc).balanceOf(address(alice)), quantityToRedeem.preciseMul(requiredUsdc, 18));
     }
 }

--- a/test/integration/IssuerWizard/redeem.t.sol
+++ b/test/integration/IssuerWizard/redeem.t.sol
@@ -27,7 +27,7 @@ contract IssuerWizardIntegrationRedeemTest is Test {
     address public chamberGodAddress = address(chamberGod);
     address public token1 = 0x2b591e99afE9f32eAA6214f7B7629768c40Eeb39; // HEX on ETH
     address public token2 = 0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e; // YFI on ETH
-    address public usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;   // USDC on ETH
+    address public usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; // USDC on ETH
     address[] public globalConstituents = new address[](2);
     uint256[] public globalQuantities = new uint256[](2);
     address[] public wizards = new address[](1);
@@ -295,10 +295,24 @@ contract IssuerWizardIntegrationRedeemTest is Test {
         issuerWizard.redeem(IChamber(address(chamber)), quantityToRedeem);
 
         assertEq(chamber.totalSupply(), 0);
-        assertGe(IERC20(token1).balanceOf(address(chamber)), quantityToRedeem.preciseMulCeil(token1Quantity, 18) - quantityToRedeem.preciseMul(token1Quantity, 18));
-        assertGe(IERC20(token2).balanceOf(address(chamber)), quantityToRedeem.preciseMulCeil(token2Quantity, 18) - quantityToRedeem.preciseMul(token2Quantity, 18));
-        assertGe(IERC20(token1).balanceOf(address(alice)), quantityToRedeem.preciseMul(token1Quantity, 18));
-        assertGe(IERC20(token2).balanceOf(address(alice)), quantityToRedeem.preciseMul(token2Quantity, 18));
+        assertGe(
+            IERC20(token1).balanceOf(address(chamber)),
+            quantityToRedeem.preciseMulCeil(token1Quantity, 18)
+                - quantityToRedeem.preciseMul(token1Quantity, 18)
+        );
+        assertGe(
+            IERC20(token2).balanceOf(address(chamber)),
+            quantityToRedeem.preciseMulCeil(token2Quantity, 18)
+                - quantityToRedeem.preciseMul(token2Quantity, 18)
+        );
+        assertGe(
+            IERC20(token1).balanceOf(address(alice)),
+            quantityToRedeem.preciseMul(token1Quantity, 18)
+        );
+        assertGe(
+            IERC20(token2).balanceOf(address(alice)),
+            quantityToRedeem.preciseMul(token2Quantity, 18)
+        );
     }
 
     /**
@@ -347,7 +361,12 @@ contract IssuerWizardIntegrationRedeemTest is Test {
         issuerWizard.redeem(IChamber(address(chamber)), quantityToRedeem);
 
         assertEq(chamber.totalSupply(), quantityToMint - quantityToRedeem);
-        assertEq(IERC20(usdc).balanceOf(address(chamber)), requiredUsdcCollateral - quantityToRedeem.preciseMul(requiredUsdc, 18));
-        assertEq(IERC20(usdc).balanceOf(address(alice)), quantityToRedeem.preciseMul(requiredUsdc, 18));
+        assertEq(
+            IERC20(usdc).balanceOf(address(chamber)),
+            requiredUsdcCollateral - quantityToRedeem.preciseMul(requiredUsdc, 18)
+        );
+        assertEq(
+            IERC20(usdc).balanceOf(address(alice)), quantityToRedeem.preciseMul(requiredUsdc, 18)
+        );
     }
 }

--- a/test/integration/IssuerWizard/redeem.t.sol
+++ b/test/integration/IssuerWizard/redeem.t.sol
@@ -140,7 +140,8 @@ contract IssuerWizardIntegrationRedeemTest is Test {
         vm.assume(token2Quantity > 0);
         vm.assume(token2Quantity < 1 ether);
         vm.assume(quantityToRedeem > 0);
-        vm.assume(quantityToRedeem < 1 ether);
+        vm.assume(quantityToRedeem < 1 ether / token1Quantity);
+        vm.assume(quantityToRedeem < 1 ether / token2Quantity);
 
         uint256[] memory testQuantities = new uint256[](2);
         testQuantities[0] = token1Quantity;

--- a/test/unit/IssuerWizard/redeem.t.sol
+++ b/test/unit/IssuerWizard/redeem.t.sol
@@ -185,6 +185,13 @@ contract IssuerWizardUnitRedeemTest is Test {
         vm.assume(quantityToRedeem > 0);
 
         vm.mockCall(
+            chamberGodAddress,
+            abi.encodeWithSelector(
+                IChamberGod(chamberGodAddress).isChamber.selector, address(chamber)
+            ),
+            abi.encode(true)
+        );
+        vm.mockCall(
             chamberAddress,
             abi.encodeWithSelector(IERC20(address(chamber)).totalSupply.selector),
             abi.encode(quantityToRedeem)

--- a/test/unit/IssuerWizard/redeem.t.sol
+++ b/test/unit/IssuerWizard/redeem.t.sol
@@ -179,9 +179,9 @@ contract IssuerWizardUnitRedeemTest is Test {
      * when all constituents have zero as quantity. This scenario should not occur thanks
      * to validations in other contracts.
      */
-    function testCannotRedeemBurnInfiniteTokensWithZeroQuantityInContituents(uint256 quantityToRedeem)
-        public
-    {
+    function testCannotRedeemBurnInfiniteTokensWithZeroQuantityInContituents(
+        uint256 quantityToRedeem
+    ) public {
         vm.assume(quantityToRedeem > 0);
 
         vm.mockCall(
@@ -430,7 +430,13 @@ contract IssuerWizardUnitRedeemTest is Test {
         assertEq(IERC20(address(chamber)).totalSupply(), 0);
         assertEq(IERC20(token1).balanceOf(alice), quantityToRedeem.preciseMul(token1Quantity, 18));
         assertEq(IERC20(token2).balanceOf(alice), quantityToRedeem.preciseMul(token2Quantity, 18));
-        assertEq(IERC20(token1).balanceOf(chamberAddress), requiredToken1Collateral - quantityToRedeem.preciseMul(token1Quantity, 18));
-        assertEq(IERC20(token2).balanceOf(chamberAddress), requiredToken2Collateral - quantityToRedeem.preciseMul(token2Quantity, 18));
+        assertEq(
+            IERC20(token1).balanceOf(chamberAddress),
+            requiredToken1Collateral - quantityToRedeem.preciseMul(token1Quantity, 18)
+        );
+        assertEq(
+            IERC20(token2).balanceOf(chamberAddress),
+            requiredToken2Collateral - quantityToRedeem.preciseMul(token2Quantity, 18)
+        );
     }
 }


### PR DESCRIPTION
Fixes #11 

- `getConstituentsQuantitiesForIssuance` is used for mint now, while `getConstituentsQuantitiesForRedeem` is used for redeem, when calculating required constituents quantities.
- `getConstituentsQuantitiesForIssuance` still guarantees overcollateralization even with small amounts. Uses `preciseMulCeil`
- `getConstituentsQuantitiesForRedeem` will revert if the redeem amount is not enough to get out from the chamber at least 1 wei of every constituent. Uses `preciseMul`
- Added tests where mint is fully overcollateralized, so every redeem will revert.
- Added tests where mint is legit collateralized, and overcalleralized, and redeem can get out some constituent tokens.
- Because someone can mint overcollaterizing, and redeem less constituent's amount that was required to mint, the chamber may have dust amounts of constituents inside. This case is fixed with a call to `updateQuantities` when collecting fees.
- New tests use USDC on purpose because of the 6 decimals requirement. Mint amounts go up to 1e12 USD value, so most cases are filled
- Two tests were removed because all chamber in tests are created though the God (no empty constituents nor 0 quantities allowed)