### PR TITLE
⚡️Use enumerable set to improve performance

### DIFF
--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -133,11 +133,11 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
         god = IChamberGod(msg.sender);
 
         for (uint256 i = 0; i < _wizards.length; i++) {
-            wizards.add(_wizards[i]);
+            require(wizards.add(_wizards[i]), "Cannot add wizard");
         }
 
         for (uint256 i = 0; i < _managers.length; i++) {
-            managers.add(_managers[i]);
+            require(managers.add(_managers[i]), "Cannot add manager");
         }
 
         for (uint256 j = 0; j < _constituents.length; j++) {
@@ -216,7 +216,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
         require(!isManager(_manager), "Already manager");
         require(_manager != address(0), "Cannot add null address");
 
-        managers.add(_manager);
+        require(managers.add(_manager), "Cannot add manager");
 
         emit ManagerAdded(_manager);
     }
@@ -229,7 +229,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
     function removeManager(address _manager) external onlyOwner nonReentrant {
         require(isManager(_manager), "Not a manager");
 
-        managers.remove(_manager);
+        require(managers.remove(_manager), "Cannot remove manager");
 
         emit ManagerRemoved(_manager);
     }
@@ -243,7 +243,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
         require(god.isWizard(_wizard), "Wizard not validated in ChamberGod");
         require(!isWizard(_wizard), "Wizard already in Chamber");
 
-        wizards.add(_wizard);
+        require(wizards.add(_wizard), "Cannot add wizard");
 
         emit WizardAdded(_wizard);
     }
@@ -256,7 +256,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
     function removeWizard(address _wizard) external onlyManager nonReentrant {
         require(isWizard(_wizard), "Wizard not in chamber");
 
-        wizards.remove(_wizard);
+        require(wizards.remove(_wizard), "Cannot remove wizard");
 
         emit WizardRemoved(_wizard);
     }
@@ -333,7 +333,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
         require(god.isAllowedContract(_target), "Contract not allowed in ChamberGod");
         require(!isAllowedContract(_target), "Contract already allowed");
 
-        allowedContracts.add(_target);
+        require(allowedContracts.add(_target), "Cannot add contract");
 
         emit AllowedContractAdded(_target);
     }
@@ -346,7 +346,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
     function removeAllowedContract(address _target) external onlyManager nonReentrant {
         require(isAllowedContract(_target), "Contract not allowed");
 
-        allowedContracts.remove(_target);
+        require(allowedContracts.remove(_target), "Cannot remove contract");
 
         emit AllowedContractRemoved(_target);
     }

--- a/src/Chamber.sol
+++ b/src/Chamber.sol
@@ -303,12 +303,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      * @return address[] Array containing the addresses of the wizards of the Chamber
      */
     function getWizards() external view returns (address[] memory) {
-        uint256 _totalWizards = wizards.length();
-        address[] memory _wizards = new address[](_totalWizards);
-        for (uint256 i = 0; i < _totalWizards; i++) {
-            _wizards[i] = wizards.at(i);
-        }
-        return _wizards;
+        return wizards.values();
     }
 
     /**
@@ -317,12 +312,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      * @return address[] Array containing the addresses of the managers of the Chamber
      */
     function getManagers() external view returns (address[] memory) {
-        uint256 _totalManagers = managers.length();
-        address[] memory _managers = new address[](_totalManagers);
-        for (uint256 i = 0; i < _totalManagers; i++) {
-            _managers[i] = managers.at(i);
-        }
-        return _managers;
+        return managers.values();
     }
 
     /**
@@ -331,12 +321,7 @@ contract Chamber is IChamber, Owned, ReentrancyGuard, ERC20 {
      * @return address[] Array containing the addresses of the allowedContracts of the Chamber
      */
     function getAllowedContracts() external view returns (address[] memory) {
-        uint256 _totalAllowedContracts = allowedContracts.length();
-        address[] memory _allowedContracts = new address[](_totalAllowedContracts);
-        for (uint256 i = 0; i < _totalAllowedContracts; i++) {
-            _allowedContracts[i] = allowedContracts.at(i);
-        }
-        return _allowedContracts;
+        return allowedContracts.values();
     }
 
     /**

--- a/src/ChamberGod.sol
+++ b/src/ChamberGod.sol
@@ -134,12 +134,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
      * @return address[]      An address array containing the Wizards
      */
     function getWizards() external view returns (address[] memory) {
-        uint256 _totalWizards = wizards.length();
-        address[] memory _wizards = new address[](_totalWizards);
-        for (uint256 i = 0; i < _totalWizards; i++) {
-            _wizards[i] = wizards.at(i);
-        }
-        return _wizards;
+        return wizards.values();
     }
 
     /**
@@ -148,12 +143,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
      * @return address[]      An address array containing the Chambers
      */
     function getChambers() external view returns (address[] memory) {
-        uint256 _totalChambers = chambers.length();
-        address[] memory _chambers = new address[](_totalChambers);
-        for (uint256 i = 0; i < _totalChambers; i++) {
-            _chambers[i] = chambers.at(i);
-        }
-        return _chambers;
+        return chambers.values();
     }
 
     /**
@@ -211,12 +201,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
      * @return address[]      An address array containing the allowed contracts
      */
     function getAllowedContracts() external view returns (address[] memory) {
-        uint256 _totalAllowedContracts = allowedContracts.length();
-        address[] memory _allowedContracts = new address[](_totalAllowedContracts);
-        for (uint256 i = 0; i < _totalAllowedContracts; i++) {
-            _allowedContracts[i] = allowedContracts.at(i);
-        }
-        return _allowedContracts;
+        return allowedContracts.values();
     }
 
     /**

--- a/src/ChamberGod.sol
+++ b/src/ChamberGod.sol
@@ -121,7 +121,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
           _managers
         );
 
-        chambers.add(address(chamber));
+        require(chambers.add(address(chamber)), "Cannot add chamber");
 
         emit ChamberCreated(address(chamber), msg.sender, _name, _symbol);
 
@@ -177,7 +177,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
         require(_wizard != address(0), "Must be a valid wizard");
         require(!isWizard(address(_wizard)), "Wizard already in ChamberGod");
 
-        wizards.add(_wizard);
+        require(wizards.add(_wizard), "Cannot add wizard");
 
         emit WizardAdded(_wizard);
     }
@@ -190,7 +190,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
     function removeWizard(address _wizard) external onlyOwner nonReentrant {
         require(isWizard(_wizard), "Wizard not valid");
 
-        wizards.remove(_wizard);
+        require(wizards.remove(_wizard), "Cannot remove wizard");
 
         emit WizardRemoved(_wizard);
     }
@@ -212,7 +212,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
     function addAllowedContract(address _target) external onlyOwner nonReentrant {
         require(!isAllowedContract(_target), "Contract already allowed");
 
-        allowedContracts.add(_target);
+        require(allowedContracts.add(_target), "Cannot add contract");
 
         emit AllowedContractAdded(_target);
     }
@@ -225,7 +225,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
     function removeAllowedContract(address _target) external onlyOwner nonReentrant {
         require(isAllowedContract(_target), "Contract not allowed");
 
-        allowedContracts.remove(_target);
+        require(allowedContracts.remove(_target), "Cannot remove contract");
 
         emit AllowedContractRemoved(_target);
     }

--- a/src/ChamberGod.sol
+++ b/src/ChamberGod.sol
@@ -43,6 +43,7 @@ pragma solidity ^0.8.17.0;
 
 import {Owned} from "solmate/auth/Owned.sol";
 import {ReentrancyGuard} from "solmate/utils/ReentrancyGuard.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {ArrayUtils} from "./lib/ArrayUtils.sol";
 import {Chamber} from "./Chamber.sol";
 import {IChamberGod} from "./interfaces/IChamberGod.sol";
@@ -53,16 +54,15 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
     //////////////////////////////////////////////////////////////*/
 
     using ArrayUtils for address[];
+    using EnumerableSet for EnumerableSet.AddressSet;
 
     /*//////////////////////////////////////////////////////////////
                               GOD STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    address[] public chambers;
-
-    address[] public wizards;
-
-    address[] public allowedContracts;
+    EnumerableSet.AddressSet private chambers;
+    EnumerableSet.AddressSet private wizards;
+    EnumerableSet.AddressSet private allowedContracts;
 
     /*//////////////////////////////////////////////////////////////
                                CONSTRUCTOR
@@ -121,7 +121,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
           _managers
         );
 
-        chambers.push(address(chamber));
+        chambers.add(address(chamber));
 
         emit ChamberCreated(address(chamber), msg.sender, _name, _symbol);
 
@@ -134,7 +134,12 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
      * @return address[]      An address array containing the Wizards
      */
     function getWizards() external view returns (address[] memory) {
-        return wizards;
+        uint256 _totalWizards = wizards.length();
+        address[] memory _wizards = new address[](_totalWizards);
+        for (uint256 i = 0; i < _totalWizards; i++) {
+            _wizards[i] = wizards.at(i);
+        }
+        return _wizards;
     }
 
     /**
@@ -143,7 +148,12 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
      * @return address[]      An address array containing the Chambers
      */
     function getChambers() external view returns (address[] memory) {
-        return chambers;
+        uint256 _totalChambers = chambers.length();
+        address[] memory _chambers = new address[](_totalChambers);
+        for (uint256 i = 0; i < _totalChambers; i++) {
+            _chambers[i] = chambers.at(i);
+        }
+        return _chambers;
     }
 
     /**
@@ -177,7 +187,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
         require(_wizard != address(0), "Must be a valid wizard");
         require(!isWizard(address(_wizard)), "Wizard already in ChamberGod");
 
-        wizards.push(_wizard);
+        wizards.add(_wizard);
 
         emit WizardAdded(_wizard);
     }
@@ -190,7 +200,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
     function removeWizard(address _wizard) external onlyOwner nonReentrant {
         require(isWizard(_wizard), "Wizard not valid");
 
-        wizards.removeStorage(_wizard);
+        wizards.remove(_wizard);
 
         emit WizardRemoved(_wizard);
     }
@@ -201,7 +211,12 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
      * @return address[]      An address array containing the allowed contracts
      */
     function getAllowedContracts() external view returns (address[] memory) {
-        return allowedContracts;
+        uint256 _totalAllowedContracts = allowedContracts.length();
+        address[] memory _allowedContracts = new address[](_totalAllowedContracts);
+        for (uint256 i = 0; i < _totalAllowedContracts; i++) {
+            _allowedContracts[i] = allowedContracts.at(i);
+        }
+        return _allowedContracts;
     }
 
     /**
@@ -212,7 +227,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
     function addAllowedContract(address _target) external onlyOwner nonReentrant {
         require(!isAllowedContract(_target), "Contract already allowed");
 
-        allowedContracts.push(_target);
+        allowedContracts.add(_target);
 
         emit AllowedContractAdded(_target);
     }
@@ -225,7 +240,7 @@ contract ChamberGod is IChamberGod, Owned, ReentrancyGuard {
     function removeAllowedContract(address _target) external onlyOwner nonReentrant {
         require(isAllowedContract(_target), "Contract not allowed");
 
-        allowedContracts.removeStorage(_target);
+        allowedContracts.remove(_target);
 
         emit AllowedContractRemoved(_target);
     }

--- a/src/RebalanceWizard.sol
+++ b/src/RebalanceWizard.sol
@@ -45,7 +45,6 @@ import {IChamber} from "./interfaces/IChamber.sol";
 import {ReentrancyGuard} from "solmate/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ArrayUtils} from "./lib/ArrayUtils.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IRebalanceWizard} from "./interfaces/IRebalanceWizard.sol";
 
@@ -55,7 +54,6 @@ contract RebalanceWizard is ReentrancyGuard, IRebalanceWizard {
     //////////////////////////////////////////////////////////////*/
 
     using SafeERC20 for IERC20;
-    using ArrayUtils for address[];
     using Address for address;
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Using EnumerableSet (from OpenZepellin) guarantees O(1) operations for `add`, `remove`, `contains`, while O(n) for returning all items in a set.
- The last operation doesn't matter as it's only going to be used for external contract reading.
- This PR allows keeping gas constant for `issue` and `redeem`, as `contains` is now O(1) and not O(n) like before (using ArrayUtils).
- Fix warnings in test

[[Ref]](https://docs.openzeppelin.com/contracts/3.x/api/utils#EnumerableSet)